### PR TITLE
fix(delivery): price auctions on posterior means, not Thompson draws

### DIFF
--- a/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
+++ b/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
@@ -118,10 +118,10 @@ final class LearningEventLog(
       }
     }
 
-    // 2. Per-creative impression tracking is now done server-side in AdServer when
-    // Selected is returned (BudgetReserved → Reserved handler), eliminating the need
-    // for a separate HTTP call that could fail. This ensures creativeStats.impressions
-    // always matches serveStats.selected.
+    // 2. Per-creative impression tracking is done server-side in AdServer at
+    // serve time (BatchReservationsResolved records recordImpression for each
+    // served winner), eliminating a separate HTTP call that could fail and
+    // keeping creativeStats.impressions aligned with serveStats.selected.
 
     // 3. Use requestId from TryReserve (budget already deducted)
     // RecordSpend will see this as duplicate and skip deduction

--- a/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
+++ b/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
@@ -19,7 +19,6 @@ import scala.util.{ Failure, Success }
  * == Learning Flow ==
  * {{{
  * logImpression(event) → TaxonomyRankerEntity ! RecordImpression(revenue)  // category-level
- *                      → AdServer ! RecordImpression(creativeId)           // per-creative
  *                      → CampaignEntity ! RecordSpend(amount)              // budget tracking
  *                      → TrackingEventJournal.writeImpression()            // dashboard projection
  *
@@ -27,6 +26,10 @@ import scala.util.{ Failure, Success }
  *                      → AdServer ! RecordClick(creativeId)                // per-creative
  *                      → TrackingEventJournal.writeClick()                 // dashboard projection
  * }}}
+ *
+ * Per-creative impressions are NOT dispatched from here: AdServer records
+ * them itself at serve time (BatchReservationsResolved), so the beacon only
+ * carries category/spend/journal signal.
  *
  * == Two-Level Thompson Sampling ==
  * - TaxonomyRankerEntity: Category-level CTR learning (Beta posterior per category per site)
@@ -120,8 +123,10 @@ final class LearningEventLog(
 
     // 2. Per-creative impression tracking is done server-side in AdServer at
     // serve time (BatchReservationsResolved records recordImpression for each
-    // served winner), eliminating a separate HTTP call that could fail and
-    // keeping creativeStats.impressions aligned with serveStats.selected.
+    // served winner except honored pins), eliminating a separate HTTP call
+    // that could fail. Note creativeStats.impressions therefore counts serves,
+    // not rendered beacons, and (unlike serveStats.selected) excludes
+    // dogeared pin-honors.
 
     // 3. Use requestId from TryReserve (budget already deducted)
     // RecordSpend will see this as duplicate and skip deduction

--- a/modules/api/src/main/scala/promovolve/api/ServeRoutes.scala
+++ b/modules/api/src/main/scala/promovolve/api/ServeRoutes.scala
@@ -507,8 +507,11 @@ final class ServeRoutes(
     val b = nowBucket()
     secretsRepo.secretFor(pub).map {
       case Some(sec) =>
-        // Include requestId in HMAC to prevent tampering
-        val data = Signer.canonical(pub, url, slot, cid, ver, b, evt) + requestId.map(r => s"|$r").getOrElse("")
+        // Bind campaign/advertiser/cpm/requestId into the HMAC so none of
+        // them can be rewritten on the beacon after serve. cpm is signed as
+        // its exact URL string (`p.toString`, matching `&cpm=$p` below).
+        val data = Signer.canonical(pub, url, slot, cid, ver, b, evt) +
+          Signer.bind(campaignId, advertiserId, cpm.map(_.toString), requestId)
         val tok = Signer.hmac256(data, sec)
         val encU = java.net.URLEncoder.encode(url, "UTF-8")
 

--- a/modules/api/src/main/scala/promovolve/api/TrackRoutes.scala
+++ b/modules/api/src/main/scala/promovolve/api/TrackRoutes.scala
@@ -50,10 +50,13 @@ final class TrackRoutes(
             get {
               parameters(
                 "pub", "url", "slot", "cid", "v".as[Long], "b".as[Long], "tok",
-                "camp".?, "adv".?, "cpm".as[Double].?, "cat".?, "rid".?, "apc".?, "pcats".?,
+                "camp".?, "adv".?, "cpm".?, "cat".?, "rid".?, "apc".?, "pcats".?,
                 "dogeared".as[Boolean].?
               ) { (pub, url, slot, cid, v, b, tok, camp, adv, cpm, cat, rid, apc, pcats, dogeared) =>
-                onSuccess(validateImp(pub, url, slot, cid, v, b, tok, rid)) {
+                // cpm kept as its raw string for signature verification; the
+                // signature binds camp/adv/cpm so a beacon can't redirect
+                // spend to another campaign or inflate the amount.
+                onSuccess(validateImp(pub, url, slot, cid, v, b, tok, camp, adv, cpm, rid)) {
                   case false => complete(StatusCodes.Forbidden)
                   case true  =>
                     // Include rid in replay key to allow multiple impressions of same creative
@@ -75,7 +78,7 @@ final class TrackRoutes(
                             ua = ua,
                             campaignId = camp,
                             advertiserId = adv,
-                            cpm = cpm,
+                            cpm = cpm.flatMap(_.toDoubleOption),
                             category = cat,
                             requestId = rid,
                             adProductCategory = apc,
@@ -94,7 +97,7 @@ final class TrackRoutes(
               parameters("pub", "url", "slot", "cid", "v".as[Long], "b".as[Long], "tok", "cat".?, "camp".?, "adv".?,
                 "rid".?, "apc".?, "pcats".?, "dogeared".as[Boolean].?) {
                 (pub, url, slot, cid, v, b, tok, cat, camp, adv, rid, apc, pcats, dogeared) =>
-                  onSuccess(validateClick(pub, url, slot, cid, v, b, tok, rid)) {
+                  onSuccess(validateClick(pub, url, slot, cid, v, b, tok, camp, adv, rid)) {
                     case false => complete(StatusCodes.Forbidden)
                     case true  =>
                       val canonical = Signer.canonical(pub, url, slot, cid, v, b, "click") +
@@ -200,7 +203,7 @@ final class TrackRoutes(
               parameters("pub", "url", "slot", "cid", "v".as[Long], "b".as[Long], "tok", "cat".?, "camp".?, "adv".?,
                 "rid".?, "apc".?, "pcats".?, "dogeared".as[Boolean].?) {
                 (pub, url, slot, cid, v, b, tok, cat, camp, adv, rid, apc, pcats, dogeared) =>
-                  onSuccess(validateCTA(pub, url, slot, cid, v, b, tok, rid)) {
+                  onSuccess(validateCTA(pub, url, slot, cid, v, b, tok, camp, adv, rid)) {
                     case false => complete(StatusCodes.Forbidden)
                     case true  =>
                       val canonical = Signer.canonical(pub, url, slot, cid, v, b, "cta") +
@@ -244,7 +247,12 @@ final class TrackRoutes(
 
   private given ExecutionContext = system.executionContext
 
-  /** Validate impression with requestId included in HMAC (prevents rid tampering) */
+  /**
+   * Validate impression. The HMAC binds camp/adv/cpm/rid (fixed order,
+   * matching `ServeRoutes.signedUrl`) so a client can't rewrite the beacon's
+   * campaign/advertiser (spend redirection) or cpm (amount inflation). cpm is
+   * verified as its raw URL string to stay byte-identical to the mint.
+   */
   private def validateImp(
       pub: String,
       url: String,
@@ -253,17 +261,20 @@ final class TrackRoutes(
       ver: Long,
       b: Long,
       tok: String,
+      camp: Option[String],
+      adv: Option[String],
+      cpm: Option[String],
       rid: Option[String]
   ): Future[Boolean] =
     secrets.secretFor(pub).map {
       case Some(sec) =>
-        val data = Signer.canonical(pub, url, slot, cid, ver, b, "imp") + rid.map(r => s"|$r").getOrElse("")
+        val data = Signer.canonical(pub, url, slot, cid, ver, b, "imp") + Signer.bind(camp, adv, cpm, rid)
         val expect = Signer.hmac256(data, sec)
         Signer.safeEq(expect, tok) && freshBucket(b)
       case None => false
     }
 
-  /** Validate click with requestId included in HMAC (prevents rid tampering) */
+  /** Validate click. HMAC binds camp/adv/rid (click carries no cpm). */
   private def validateClick(
       pub: String,
       url: String,
@@ -272,17 +283,19 @@ final class TrackRoutes(
       ver: Long,
       b: Long,
       tok: String,
+      camp: Option[String],
+      adv: Option[String],
       rid: Option[String]
   ): Future[Boolean] =
     secrets.secretFor(pub).map {
       case Some(sec) =>
-        val data = Signer.canonical(pub, url, slot, cid, ver, b, "click") + rid.map(r => s"|$r").getOrElse("")
+        val data = Signer.canonical(pub, url, slot, cid, ver, b, "click") + Signer.bind(camp, adv, None, rid)
         val expect = Signer.hmac256(data, sec)
         Signer.safeEq(expect, tok) && freshBucket(b)
       case None => false
     }
 
-  /** Validate CTA click with requestId included in HMAC */
+  /** Validate CTA click. HMAC binds camp/adv/rid (cta carries no cpm). */
   private def validateCTA(
       pub: String,
       url: String,
@@ -291,11 +304,13 @@ final class TrackRoutes(
       ver: Long,
       b: Long,
       tok: String,
+      camp: Option[String],
+      adv: Option[String],
       rid: Option[String]
   ): Future[Boolean] =
     secrets.secretFor(pub).map {
       case Some(sec) =>
-        val data = Signer.canonical(pub, url, slot, cid, ver, b, "cta") + rid.map(r => s"|$r").getOrElse("")
+        val data = Signer.canonical(pub, url, slot, cid, ver, b, "cta") + Signer.bind(camp, adv, None, rid)
         val expect = Signer.hmac256(data, sec)
         Signer.safeEq(expect, tok) && freshBucket(b)
       case None => false

--- a/modules/core/src/main/scala/promovolve/common/Signer.scala
+++ b/modules/core/src/main/scala/promovolve/common/Signer.scala
@@ -17,16 +17,27 @@ object Signer {
     s"$pub|$url|$slot|$cid|$ver|$bucket|$evt"
 
   /**
-   * Append optional binding fields to a canonical string in a fixed order,
-   * each rendered as `|value` and absent ones skipped. The mint site and the
-   * verify site MUST pass the same fields in the same order. Used to bind
-   * campaign / advertiser / cpm / requestId into the tracking-token signature
-   * so a client can't rewrite them after serve (e.g. redirecting a beacon's
-   * spend to a competitor's campaign). Pass cpm as its exact URL string form
-   * so the signature is byte-identical without a Double round-trip.
+   * Append optional binding fields to a canonical string in a fixed order.
+   * The mint site and the verify site MUST pass the same fields in the same
+   * order. Used to bind campaign / advertiser / cpm / requestId into the
+   * tracking-token signature so a client can't rewrite them after serve
+   * (e.g. redirecting a beacon's spend to a competitor's campaign). Pass cpm
+   * as its exact URL string form so the signature is byte-identical without
+   * a Double round-trip.
+   *
+   * The rendering is injective for a fixed arity: every field emits its own
+   * `|` separator (absent ones included), present values are URL-encoded so
+   * they cannot contain a literal `|`, and the `=` marker distinguishes
+   * `Some("")` from `None` (`=` itself is never produced by the encoding).
+   * Skipping absent fields or joining raw values would let a client shift
+   * bytes across field boundaries — e.g. `camp=c|a` re-verifying as
+   * `camp=c, adv=a` — and forge a beacon the mint never signed.
    */
   def bind(fields: Option[String]*): String =
-    fields.flatten.map(f => s"|$f").mkString
+    fields.map {
+      case Some(v) => "|=" + java.net.URLEncoder.encode(v, "UTF-8")
+      case None    => "|"
+    }.mkString
 
   def hmac256(data: String, secret: Array[Byte]): String = {
     val mac = Mac.getInstance("HmacSHA256")

--- a/modules/core/src/main/scala/promovolve/common/Signer.scala
+++ b/modules/core/src/main/scala/promovolve/common/Signer.scala
@@ -16,6 +16,18 @@ object Signer {
   ): String =
     s"$pub|$url|$slot|$cid|$ver|$bucket|$evt"
 
+  /**
+   * Append optional binding fields to a canonical string in a fixed order,
+   * each rendered as `|value` and absent ones skipped. The mint site and the
+   * verify site MUST pass the same fields in the same order. Used to bind
+   * campaign / advertiser / cpm / requestId into the tracking-token signature
+   * so a client can't rewrite them after serve (e.g. redirecting a beacon's
+   * spend to a competitor's campaign). Pass cpm as its exact URL string form
+   * so the signature is byte-identical without a Double round-trip.
+   */
+  def bind(fields: Option[String]*): String =
+    fields.flatten.map(f => s"|$f").mkString
+
   def hmac256(data: String, secret: Array[Byte]): String = {
     val mac = Mac.getInstance("HmacSHA256")
     mac.init(new SecretKeySpec(secret, "HmacSHA256"))

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
@@ -136,6 +136,34 @@ object AdServer {
     }
 
   /**
+   * Served winners that must record a per-creative impression: every filled
+   * slot EXCEPT honored dog-ear pins (which stay learning-silent, matching the
+   * billing/CTR treatment in LearningEventLog). Pure — extracted from the
+   * BatchReservationsResolved handler so the "impress winners, skip honored
+   * pins" contract is unit-testable.
+   */
+  private[delivery] def impressedCreatives(outcomes: Vector[Protocol.BatchSlotOutcome]): Vector[CreativeId] =
+    outcomes.flatMap(o => o.winner.filterNot(_ => o.dogear.exists(_.honored)).map(_.creativeId))
+
+  /**
+   * Pure freshness-token math for a page's classification (see
+   * `reclassifyInMsFor`). Returns ms until the page should be re-classified:
+   * `> 0` fresh (the ad tag does nothing), `<= 0` needs (re)classification —
+   * cold (`None` → 0) or stale (aged past the window). The window is the
+   * publisher's content-recency window when set (`> 0`), else the 48h default.
+   * Extracted so the recency-window handling is unit-testable — it was once
+   * hardcoded to 0 downstream, silently forcing the default and ignoring the
+   * publisher's setting.
+   */
+  private[delivery] def reclassifyInMs(classifiedAtMs: Option[Long], recencyWindowMs: Long, now: Long): Long = {
+    val window = if (recencyWindowMs > 0) recencyWindowMs else DefaultReclassifyWindowMs
+    classifiedAtMs match {
+      case Some(ts) => (ts + window) - now
+      case None     => 0L
+    }
+  }
+
+  /**
    * Partition candidates by the advertiser-side site-domain blocklist.
    * Direction inversion vs. publisher-side: drop the advertiser, not the
    * landing domain. No-op (everything passes through) when the site's
@@ -935,13 +963,8 @@ private[delivery] class AdServer(
   // <= 0 means "(re)classify now" — covers both never-classified (no record →
   // 0) and stale (aged past the window). > 0 means fresh. The reclassify window
   // is the content-recency window when set, else a 48h default.
-  private def reclassifyInMsFor(urlValue: String, recencyWindowMs: Long): Long = {
-    val window = if (recencyWindowMs > 0) recencyWindowMs else AdServer.DefaultReclassifyWindowMs
-    classifiedAtMsByUrl.get(urlValue) match {
-      case Some(ts) => (ts + window) - System.currentTimeMillis()
-      case None     => 0L
-    }
-  }
+  private def reclassifyInMsFor(urlValue: String, recencyWindowMs: Long): Long =
+    AdServer.reclassifyInMs(classifiedAtMsByUrl.get(urlValue), recencyWindowMs, System.currentTimeMillis())
   // Track pending creative IDs per (url|slot) to suppress duplicate SSE events on re-auction
   private var lastPendingCreativeIds: Map[String, Set[String]] = Map.empty
   // Site floor CPM for clearing price floor (synced via DData PacingConfig)
@@ -2627,8 +2650,7 @@ private[delivery] class AdServer(
         // handler; the batch path is now the only serve path, so it must
         // record here. Pin re-encounters (dogeared) stay learning-silent,
         // matching the billing/CTR treatment in LearningEventLog.
-        val impressedCreatives: Vector[CreativeId] =
-          outcomes.flatMap(o => o.winner.filterNot(_ => o.dogear.exists(_.honored)).map(_.creativeId))
+        val impressedCreatives: Vector[CreativeId] = AdServer.impressedCreatives(outcomes)
         val updatedCreativeStats =
           impressedCreatives.foldLeft(creativeStats) { (acc, cid) =>
             acc.updatedWith(cid)(_.orElse(Some(CreativeStats())).map(_.recordImpression(now)))

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
@@ -1431,24 +1431,19 @@ private[delivery] class AdServer(
               AdvertiserEntity.RevokeCreativeApproval(CreativeId(creativeId), siteId, system.ignoreRef)
             }
             store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
+            // Strip ONLY this campaign's creatives from in-memory approval
+            // state, resolved from the store rows. The slot-key index
+            // (idsForKey) conflates every campaign sharing a slot key, so
+            // stripping by index would revoke co-tenant campaigns' approvals.
+            ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
             if (rows.nonEmpty)
               log.info("Revoked {} approvals for paused campaign {} on site {}", rows.size: java.lang.Integer,
                 campaignId.value, siteId.value)
           }
         }
-        val pausedCampaignKeys = keysByCampaign.getOrElse(campaignId, Set.empty)
-        val pausedCreativeIds: Set[CreativeId] =
-          if (revokeApprovals)
-            pausedCampaignKeys.flatMap { key =>
-              idsForKey.get(key).map(_._2).getOrElse(Set.empty)
-            }
-          else Set.empty
         behavior(state.copy(
           participatingCampaigns = participatingCampaigns - campaignId,
-          keysByCampaign = keysByCampaign - campaignId,
-          keysByCreative = keysByCreative -- pausedCreativeIds,
-          persistedApprovedIds = persistedApprovedIds -- pausedCreativeIds,
-          pinnedCreativeIds = pinnedCreativeIds -- pausedCreativeIds
+          keysByCampaign = keysByCampaign - campaignId
         ))
 
       case Protocol.EvictCampaignFromSite(campaignId) =>
@@ -1465,17 +1460,29 @@ private[delivery] class AdServer(
             log.info("Removed {} pending selections for narrowed-off campaign {}", count, campaignId.value)
           }
         }
-        store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
-        val evictedCampaignKeys = keysByCampaign.getOrElse(campaignId, Set.empty)
-        val evictedCreativeIds: Set[CreativeId] = evictedCampaignKeys.flatMap { key =>
-          idsForKey.get(key).map(_._2).getOrElse(Set.empty)
+        // Strip ONLY this campaign's creatives from in-memory approval state,
+        // resolved from the store rows before deletion — not the slot-key
+        // index, which conflates co-tenant campaigns sharing a slot key.
+        store.getApprovedCreativeAdvertisersByCampaign(siteId.value, campaignId.value).foreach { rows =>
+          store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
+          ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
         }
         behavior(state.copy(
           participatingCampaigns = participatingCampaigns - campaignId,
-          keysByCampaign = keysByCampaign - campaignId,
-          persistedApprovedIds = persistedApprovedIds -- evictedCreativeIds,
-          pinnedCreativeIds = pinnedCreativeIds -- evictedCreativeIds
+          keysByCampaign = keysByCampaign - campaignId
         ))
+
+      case Protocol.CampaignApprovalsRevoked(campaignId, creativeIds) =>
+        if (creativeIds.isEmpty) Behaviors.same
+        else {
+          log.info("Stripping {} approved creatives for revoked campaign {} on site {}",
+            creativeIds.size: java.lang.Integer, campaignId.value, siteId.value)
+          behavior(state.copy(
+            keysByCreative = keysByCreative -- creativeIds,
+            persistedApprovedIds = persistedApprovedIds -- creativeIds,
+            pinnedCreativeIds = pinnedCreativeIds -- creativeIds
+          ))
+        }
 
       case Protocol.EvictCampaignFromSlots(campaignId, slotKeys) =>
         // Topic-narrow eviction: the advertiser dropped a category, so this
@@ -2167,7 +2174,7 @@ private[delivery] class AdServer(
       // ResetDayStart fan-out, traffic shape, warmup gating) lives in
       // recordRequestArrival above.
 
-      case BatchSelect(url, slots, _, replyTo, excludedCreatives, excludedCampaigns) =>
+      case BatchSelect(url, slots, contentRecencyWindowMs, replyTo, excludedCreatives, excludedCampaigns) =>
         val hostOk = AdServer.hostMatches(url.value, verifiedHost)
         if (!hostOk) {
           log.warn("Batch serve rejected: host-mismatch site={} url={}", siteId.value, url.value)
@@ -2243,10 +2250,11 @@ private[delivery] class AdServer(
                     }
                     BatchSelectViewLoaded(
                       view = merged,
-                      url, slots, 0L, replyTo, excludedCreatives, excludedCampaigns
+                      url, slots, contentRecencyWindowMs, replyTo, excludedCreatives, excludedCampaigns
                     )
                   case scala.util.Failure(_) =>
-                    BatchSelectViewLoaded(None, url, slots, 0L, replyTo, excludedCreatives, excludedCampaigns)
+                    BatchSelectViewLoaded(None, url, slots, contentRecencyWindowMs, replyTo, excludedCreatives,
+                      excludedCampaigns)
                 }
                 behavior(newState)
               }
@@ -2599,11 +2607,25 @@ private[delivery] class AdServer(
           outcomes.flatMap(o => o.dogear.filter(_.honored).flatMap(_ => o.winner.map(_.creativeId))).toSet
         val updatedPinned =
           if (honoredPins.isEmpty) state.pinnedCreativeIds else state.pinnedCreativeIds ++ honoredPins
+        // Record a per-creative impression for every served winner so
+        // Thompson Sampling scores against real Beta posteriors instead
+        // of scoring every creative through the cold branch forever.
+        // The retired per-slot Select path used to do this via a Reserved
+        // handler; the batch path is now the only serve path, so it must
+        // record here. Pin re-encounters (dogeared) stay learning-silent,
+        // matching the billing/CTR treatment in LearningEventLog.
+        val impressedCreatives: Vector[CreativeId] =
+          outcomes.flatMap(o => o.winner.filterNot(_ => o.dogear.exists(_.honored)).map(_.creativeId))
+        val updatedCreativeStats =
+          impressedCreatives.foldLeft(creativeStats) { (acc, cid) =>
+            acc.updatedWith(cid)(_.orElse(Some(CreativeStats())).map(_.recordImpression(now)))
+          }
         behavior(state.copy(
           pendingSpendByCampaign = updatedPending,
           pageWinners = updatedPageWinners,
           serveStats = updatedServeStats,
-          pinnedCreativeIds = updatedPinned
+          pinnedCreativeIds = updatedPinned,
+          creativeStats = updatedCreativeStats
         ))
     }
   }

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
@@ -309,7 +309,7 @@ object AdServer {
           .collectFirst { case (c, s) if c.category == winner.category => s.meanScore }
           .getOrElse(0.0)
         val clearing = ThompsonSampling.qualityAdjustedClearing(
-          winnerEngagement = winnerScore.engagement,
+          winnerEngagement = winnerScore.meanEngagement,
           winnerBid = winner.cpm,
           bestLoserScore = bestLoserScore,
           alpha = alpha,
@@ -383,7 +383,7 @@ object AdServer {
         .collectFirst { case (c, s) if c.category == winner.category => s.meanScore }
         .getOrElse(0.0)
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerEngagement = winnerScore.engagement,
+        winnerEngagement = winnerScore.meanEngagement,
         winnerBid = winner.cpm,
         bestLoserScore = bestLoserScore,
         alpha = alpha,
@@ -1425,20 +1425,27 @@ private[delivery] class AdServer(
         // source), so Creative.approvedSites clears and the resumed bids read
         // as pending, not floor-teaching.
         if (revokeApprovals) {
-          store.getApprovedCreativeAdvertisersByCampaign(siteId.value, campaignId.value).foreach { rows =>
-            rows.foreach { case (creativeId, advertiserId) =>
-              sharding.entityRefFor(AdvertiserEntity.TypeKey, advertiserId) !
-              AdvertiserEntity.RevokeCreativeApproval(CreativeId(creativeId), siteId, system.ignoreRef)
-            }
-            store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
-            // Strip ONLY this campaign's creatives from in-memory approval
-            // state, resolved from the store rows. The slot-key index
-            // (idsForKey) conflates every campaign sharing a slot key, so
-            // stripping by index would revoke co-tenant campaigns' approvals.
-            ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
-            if (rows.nonEmpty)
-              log.info("Revoked {} approvals for paused campaign {} on site {}", rows.size: java.lang.Integer,
-                campaignId.value, siteId.value)
+          store.getApprovedCreativeAdvertisersByCampaign(siteId.value, campaignId.value).onComplete {
+            case Success(rows) =>
+              rows.foreach { case (creativeId, advertiserId) =>
+                sharding.entityRefFor(AdvertiserEntity.TypeKey, advertiserId) !
+                AdvertiserEntity.RevokeCreativeApproval(CreativeId(creativeId), siteId, system.ignoreRef)
+              }
+              store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
+              // Strip ONLY this campaign's creatives from in-memory approval
+              // state, resolved from the store rows. The slot-key index
+              // (idsForKey) conflates every campaign sharing a slot key, so
+              // stripping by index would revoke co-tenant campaigns' approvals.
+              ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
+              if (rows.nonEmpty)
+                log.info("Revoked {} approvals for paused campaign {} on site {}", rows.size: java.lang.Integer,
+                  campaignId.value, siteId.value)
+            case Failure(ex) =>
+              // Nothing was revoked: no AdvertiserEntity announce, no DB delete,
+              // no in-memory strip — memory and DB stay consistent (both keep
+              // the approvals), but the pause did NOT revoke. Surface it.
+              log.error("Failed to load approvals for paused campaign {} on site {} — revocation skipped: {}",
+                campaignId.value, siteId.value, ex.getMessage)
           }
         }
         behavior(state.copy(
@@ -1463,9 +1470,15 @@ private[delivery] class AdServer(
         // Strip ONLY this campaign's creatives from in-memory approval state,
         // resolved from the store rows before deletion — not the slot-key
         // index, which conflates co-tenant campaigns sharing a slot key.
-        store.getApprovedCreativeAdvertisersByCampaign(siteId.value, campaignId.value).foreach { rows =>
-          store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
-          ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
+        store.getApprovedCreativeAdvertisersByCampaign(siteId.value, campaignId.value).onComplete {
+          case Success(rows) =>
+            store.deleteApprovedByCampaignId(siteId.value, campaignId.value)
+            ctx.self ! Protocol.CampaignApprovalsRevoked(campaignId, rows.keySet.map(CreativeId(_)))
+          case Failure(ex) =>
+            // Neither the DB delete nor the in-memory strip ran — consistent
+            // (both keep the approvals) but the eviction did NOT revoke them.
+            log.error("Failed to load approvals for evicted campaign {} on site {} — revocation skipped: {}",
+              campaignId.value, siteId.value, ex.getMessage)
         }
         behavior(state.copy(
           participatingCampaigns = participatingCampaigns - campaignId,

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
@@ -302,11 +302,14 @@ object AdServer {
         val sortedEligible = eligible.sortBy { case (_, s) => -s.score }
         val (winner, winnerScore) = sortedEligible.head
         // Same-category second price, clamped to the winner's category floor.
+        // Pricing reads the posterior-MEAN side of CandidateScore (meanScore
+        // / engagement), never the Thompson draws — sample for allocation,
+        // price on means, so the same auction state clears at the same price.
         val bestLoserScore = sortedEligible.tail
-          .collectFirst { case (c, s) if c.category == winner.category => s.score }
+          .collectFirst { case (c, s) if c.category == winner.category => s.meanScore }
           .getOrElse(0.0)
         val clearing = ThompsonSampling.qualityAdjustedClearing(
-          winnerSampledCtr = winnerScore.sampledCtr,
+          winnerEngagement = winnerScore.engagement,
           winnerBid = winner.cpm,
           bestLoserScore = bestLoserScore,
           alpha = alpha,
@@ -331,9 +334,10 @@ object AdServer {
    * hard-dedup logic from [[batchAssign]] but scoped to a single
    * slot so the retry path can reuse it unchanged.
    *
-   * Clearing is the second-best score among the slot's eligible
-   * candidates inverted through the score formula given the winner's
-   * sampled CTR (see `ThompsonSampling.qualityAdjustedClearing`).
+   * Clearing is the runner-up's posterior-mean score inverted through
+   * the score formula given the winner's posterior-mean engagement
+   * (see `ThompsonSampling.qualityAdjustedClearing`) — selection
+   * samples, pricing is deterministic given the stats.
    * Returns `siteFloor` clearing when only one candidate fits.
    */
   def pickBestForSlot(
@@ -373,12 +377,13 @@ object AdServer {
       val (winner, winnerScore) = sorted.head
       // Same-category second price: price the winner against the best loser
       // IN ITS OWN category (cross-category runners-up never set the price),
-      // clamped to the winner's category floor.
+      // clamped to the winner's category floor. Pricing reads the posterior-
+      // MEAN side of CandidateScore, never the Thompson draws.
       val bestLoserScore = sorted.tail
-        .collectFirst { case (c, s) if c.category == winner.category => s.score }
+        .collectFirst { case (c, s) if c.category == winner.category => s.meanScore }
         .getOrElse(0.0)
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = winnerScore.sampledCtr,
+        winnerEngagement = winnerScore.engagement,
         winnerBid = winner.cpm,
         bestLoserScore = bestLoserScore,
         alpha = alpha,

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/Protocol.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/Protocol.scala
@@ -891,6 +891,20 @@ object Protocol {
       attempt: Int
   ) extends Command
 
+  /**
+   * Internal: the approved creatives to strip from in-memory approval state
+   * for a campaign whose approvals were revoked (pause / site-narrow
+   * eviction). Carries the campaign's OWN creatives, resolved from the
+   * approvals store — the in-memory slot-key index conflates every campaign
+   * sharing a slot key, so stripping by index would revoke co-tenant
+   * campaigns' approvals too (their DB rows survive → memory/DB divergence,
+   * spurious re-queue as pending, voided reader pins).
+   */
+  private[delivery] final case class CampaignApprovalsRevoked(
+      campaignId: CampaignId,
+      creativeIds: Set[CreativeId]
+  ) extends Command
+
   /** Internal: traffic shape snapshot save completed */
   private[delivery] final case class TrafficShapeSnapshotSaveResult(
       error: Option[Throwable]

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/ThompsonSampling.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/ThompsonSampling.scala
@@ -29,7 +29,7 @@ object ThompsonSampling {
    * then greedy-picks across slots.
    *
    * `score` and `sampledCtr` come from the Thompson draws — allocation
-   * explores. `engagement` and `meanScore` are the same combiner
+   * explores. `meanEngagement` and `meanScore` are the same combiner
    * evaluated at the posterior MEANS — deterministic given the
    * creative's stats — and exist solely for pricing: sample for
    * allocation, price on means (see [[qualityAdjustedClearing]]).
@@ -37,7 +37,7 @@ object ThompsonSampling {
   final case class CandidateScore(
       score: Double,
       sampledCtr: Double,
-      engagement: Double,
+      meanEngagement: Double,
       meanScore: Double,
       debugInfo: String
   )
@@ -64,8 +64,8 @@ object ThompsonSampling {
    * }}}
    *
    * Both inputs must come from the posterior-MEAN side of
-   * [[CandidateScore]] (`engagement` for the winner, `meanScore` for
-   * the runner-up), never from the Thompson draws: sample for
+   * [[CandidateScore]] (`meanEngagement` for the winner, `meanScore`
+   * for the runner-up), never from the Thompson draws: sample for
    * allocation, price on means. This keeps the price reproducible
    * from observable state (same auction state → same price) and
    * symmetric — the winner's fold posterior and newcomer bonus
@@ -212,7 +212,7 @@ object ThompsonSampling {
     CandidateScore(
       score = score,
       sampledCtr = sampledCtr,
-      engagement = meanEngagement,
+      meanEngagement = meanEngagement,
       meanScore = meanEngagement * cpmFactor,
       debugInfo = s"$ctrInfo|$foldInfo$bonusInfo"
     )

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/ThompsonSampling.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/ThompsonSampling.scala
@@ -10,8 +10,8 @@ import promovolve.publisher.CandidateView
  * - Prior: Beta(1, 1) = Uniform(0, 1)
  * - Posterior: Beta(clicks + 1, non-clicks + 1)
  *
- * Selection score combines sampled CTR with CPM:
- *   score = sampledCTR * CPM^α
+ * Selection score combines sampled engagement with CPM:
+ *   score = (sampledCTR + FoldWeight × sampledFoldRate + newcomerBonus) * CPM^α
  *
  * Where α (bidWeight) is publisher-configurable:
  *   - α=0.3 (Discovery): quality dominates, small advertisers compete
@@ -27,10 +27,18 @@ object ThompsonSampling {
    * Per-candidate score plus the inputs that produced it. The batch
    * path computes this once per candidate against the joint pool
    * then greedy-picks across slots.
+   *
+   * `score` and `sampledCtr` come from the Thompson draws — allocation
+   * explores. `engagement` and `meanScore` are the same combiner
+   * evaluated at the posterior MEANS — deterministic given the
+   * creative's stats — and exist solely for pricing: sample for
+   * allocation, price on means (see [[qualityAdjustedClearing]]).
    */
   final case class CandidateScore(
       score: Double,
       sampledCtr: Double,
+      engagement: Double,
+      meanScore: Double,
       debugInfo: String
   )
 
@@ -46,32 +54,41 @@ object ThompsonSampling {
   /**
    * Quality-adjusted clearing price for an Exploitation winner.
    *
-   * Inverts the score formula `score = sampledCTR × CPM^α` against
+   * Inverts the full score formula `score = engagement × CPM^α`
+   * (engagement = ctr + FoldWeight × foldRate + newcomerBonus) against
    * the runner-up's score: the winner pays the minimum CPM at which
-   * their score still beats the runner-up given their sampled CTR.
+   * their score still beats the runner-up given their own engagement.
    *
    * {{{
-   *   clearingCpm = (bestLoserScore / winnerSampledCtr) ^ (1/α)
+   *   clearingCpm = (bestLoserScore / winnerEngagement) ^ (1/α)
    * }}}
+   *
+   * Both inputs must come from the posterior-MEAN side of
+   * [[CandidateScore]] (`engagement` for the winner, `meanScore` for
+   * the runner-up), never from the Thompson draws: sample for
+   * allocation, price on means. This keeps the price reproducible
+   * from observable state (same auction state → same price) and
+   * symmetric — the winner's fold posterior and newcomer bonus
+   * discount its price exactly as the runner-up's raise it.
    *
    * Clamped to `[siteFloor, winnerBid]`. Returns `siteFloor` when
    * there is no runner-up (`bestLoserScore = 0`, e.g. only one
-   * eligible candidate fits the slot), when the winner's sampled
-   * CTR is zero (degenerate cold start), or when α is non-positive.
+   * eligible candidate fits the slot), when the winner's engagement
+   * is zero (degenerate), or when α is non-positive.
    *
    * Pure — depends only on its arguments. Used by both the per-slot
    * exploitation path and the batch-serve assignment so prices stay
    * comparable under the same pool.
    */
   def qualityAdjustedClearing(
-      winnerSampledCtr: Double,
+      winnerEngagement: Double,
       winnerBid: CPM,
       bestLoserScore: Double,
       alpha: Double,
       siteFloor: CPM
   ): CPM = {
-    if (winnerSampledCtr > 0 && bestLoserScore > 0 && alpha > 0) {
-      val q = math.pow(bestLoserScore / winnerSampledCtr, 1.0 / alpha)
+    if (winnerEngagement > 0 && bestLoserScore > 0 && alpha > 0) {
+      val q = math.pow(bestLoserScore / winnerEngagement, 1.0 / alpha)
       CPM.max(CPM.min(CPM(q), winnerBid), siteFloor)
     } else {
       siteFloor
@@ -107,6 +124,18 @@ object ThompsonSampling {
   val NewcomerDecayImpressions: Int = 50
 
   /**
+   * Cold-start fold-rate prior: Beta(1, 3), mean 0.25. A uniform
+   * Beta(1,1) prior (mean 0.5) gave cold creatives an expected fold
+   * component of FoldWeight × 0.5 = 1.0 — an order of magnitude above
+   * typical warm fold components (0.02–0.1) — so a newly introduced
+   * creative won its slot near-deterministically. Beta(1,3) keeps
+   * genuine Thompson exploration on the fold dimension while
+   * `newcomerBonus` stays the primary exploration knob.
+   */
+  val ColdFoldPriorAlpha: Double = 1.0
+  val ColdFoldPriorBeta: Double = 3.0
+
+  /**
    * Linearly-decaying newcomer bonus. Zero once the creative has
    * accumulated NewcomerDecayImpressions impressions.
    */
@@ -124,6 +153,10 @@ object ThompsonSampling {
    * combined linearly (`ctr + FoldWeight * foldRate`) before being
    * multiplied by `cpm^alpha` to produce the auction score.
    *
+   * Alongside the sampled score, the same combiner is evaluated at
+   * the posterior MEANS into `engagement` / `meanScore` — the
+   * deterministic pricing inputs for [[qualityAdjustedClearing]].
+   *
    * Used by the batch-serve greedy assignment.
    */
   def scoreCandidate(
@@ -132,41 +165,57 @@ object ThompsonSampling {
       rng: scala.util.Random,
       alpha: Double
   ): CandidateScore = {
-    val (sampledCtr, ctrInfo, foldComponent, foldInfo) = if (stats.impressions == 0) {
-      // Cold start. CTR uses the categoryScore prior (page-classification
-      // signal we DO have). Fold-rate has no comparable prior, so we
-      // sample from Beta(1,1) — uniform [0,1] — for proper Thompson
-      // exploration on the fold dimension. Without this, cold creatives
-      // can never beat warm fold-rich ones (their foldComponent stays
-      // at 0 while a warm creative accrues up to FoldWeight×foldRate),
-      // so newly introduced creatives never win the auction.
-      val ctr = candidate.categoryScore + (rng.nextDouble() * 0.3 - 0.15)
-      val foldRate = sampleBeta(1.0, 1.0, rng)
-      (
-        ctr,
-        s"cold(catScore=${candidate.categoryScore})",
-        FoldWeight * foldRate,
-        s"fold=cold-Beta(1,1)×$FoldWeight"
-      )
-    } else {
-      val cA = stats.clicks.toDouble + 1.0
-      val cB = (stats.impressions - stats.clicks).toDouble + 1.0
-      val ctr = sampleBeta(cA, cB, rng)
-      val fA = stats.folds.toDouble + 1.0
-      val fB = (stats.impressions - stats.folds).toDouble + 1.0
-      val foldRate = sampleBeta(fA, fB, rng)
-      (
-        ctr,
-        s"Beta(${cA.toInt},${cB.toInt})",
-        FoldWeight * foldRate,
-        s"FoldBeta(${fA.toInt},${fB.toInt})×$FoldWeight"
-      )
-    }
+    val (sampledCtr, meanCtr, ctrInfo, foldComponent, meanFoldComponent, foldInfo) =
+      if (stats.impressions == 0) {
+        // Cold start. CTR uses the categoryScore prior (page-classification
+        // signal we DO have), clamped positive — a low categoryScore minus
+        // jitter must not produce a negative CTR sample. Fold-rate has no
+        // comparable prior, so we sample from the Beta(1,3) cold prior for
+        // proper Thompson exploration on the fold dimension. Without this,
+        // cold creatives can never beat warm fold-rich ones (their
+        // foldComponent stays at 0 while a warm creative accrues up to
+        // FoldWeight×foldRate), so newly introduced creatives never win
+        // the auction.
+        val ctr = math.max(0.001, candidate.categoryScore + (rng.nextDouble() * 0.3 - 0.15))
+        val foldRate = sampleBeta(ColdFoldPriorAlpha, ColdFoldPriorBeta, rng)
+        val meanFoldRate = ColdFoldPriorAlpha / (ColdFoldPriorAlpha + ColdFoldPriorBeta)
+        (
+          ctr,
+          math.max(0.001, candidate.categoryScore),
+          s"cold(catScore=${candidate.categoryScore})",
+          FoldWeight * foldRate,
+          FoldWeight * meanFoldRate,
+          s"fold=cold-Beta(${ColdFoldPriorAlpha.toInt},${ColdFoldPriorBeta.toInt})×$FoldWeight"
+        )
+      } else {
+        val cA = stats.clicks.toDouble + 1.0
+        val cB = (stats.impressions - stats.clicks).toDouble + 1.0
+        val ctr = sampleBeta(cA, cB, rng)
+        val fA = stats.folds.toDouble + 1.0
+        val fB = (stats.impressions - stats.folds).toDouble + 1.0
+        val foldRate = sampleBeta(fA, fB, rng)
+        (
+          ctr,
+          cA / (cA + cB),
+          s"Beta(${cA.toInt},${cB.toInt})",
+          FoldWeight * foldRate,
+          FoldWeight * (fA / (fA + fB)),
+          s"FoldBeta(${fA.toInt},${fB.toInt})×$FoldWeight"
+        )
+      }
     val bonus = newcomerBonus(stats.impressions)
-    val engagement = sampledCtr + foldComponent + bonus
-    val score = engagement * cpmScore(candidate.cpm.toDouble, alpha)
+    val sampledEngagement = sampledCtr + foldComponent + bonus
+    val meanEngagement = meanCtr + meanFoldComponent + bonus
+    val cpmFactor = cpmScore(candidate.cpm.toDouble, alpha)
+    val score = sampledEngagement * cpmFactor
     val bonusInfo = if (bonus > 0) f"|newBonus=$bonus%.2f" else ""
-    CandidateScore(score, sampledCtr, s"$ctrInfo|$foldInfo$bonusInfo")
+    CandidateScore(
+      score = score,
+      sampledCtr = sampledCtr,
+      engagement = meanEngagement,
+      meanScore = meanEngagement * cpmFactor,
+      debugInfo = s"$ctrInfo|$foldInfo$bonusInfo"
+    )
   }
 
   /**

--- a/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
@@ -44,7 +44,7 @@ class SignerSpec extends AnyWordSpec with Matchers {
 
     "be order-sensitive so a field swap changes the string" in {
       Signer.bind(Some("camp"), Some("adv")) should not be
-        Signer.bind(Some("adv"), Some("camp"))
+      Signer.bind(Some("adv"), Some("camp"))
     }
 
     "be injective: a value containing the delimiter cannot emulate two fields" in {

--- a/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
@@ -1,0 +1,87 @@
+package promovolve.common
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Pure tests for `Signer`, focused on the tracking-token binding contract.
+ *
+ * Tracking beacons carry `camp` / `adv` / `cpm` as query params. They MUST be
+ * bound into the HMAC (via `Signer.bind`) so a client that received one valid
+ * serve token can't rewrite the beacon to charge a competitor's campaign or
+ * inflate the amount. These tests pin that contract at the primitive level;
+ * the route-level wiring lives in ServeRoutes/TrackRoutes.
+ */
+class SignerSpec extends AnyWordSpec with Matchers {
+
+  private val secret = "test-secret-bytes-min-32-bytes-long".getBytes("UTF-8")
+
+  private val pub = "publisher-1"
+  private val url = "https://example.com/article"
+  private val slot = "leader-top"
+  private val cid = "ad_7f3a9b"
+  private val ver = 1234567890L
+  private val bucket = 29000000L
+
+  // Mirror the mint/verify sites: canonical + bound (camp, adv, cpm, rid).
+  private def impToken(
+      camp: Option[String],
+      adv: Option[String],
+      cpm: Option[String],
+      rid: Option[String]
+  ): String =
+    Signer.hmac256(
+      Signer.canonical(pub, url, slot, cid, ver, bucket, "imp") + Signer.bind(camp, adv, cpm, rid),
+      secret
+    )
+
+  "Signer.bind" should {
+    "render present fields as |value in order and skip absent ones" in {
+      Signer.bind(Some("a"), Some("b"), Some("c")) shouldBe "|a|b|c"
+      Signer.bind(Some("a"), None, Some("c")) shouldBe "|a|c"
+      Signer.bind(None, None, None) shouldBe ""
+    }
+
+    "be order-sensitive so a field swap changes the string" in {
+      Signer.bind(Some("camp"), Some("adv")) should not be
+        Signer.bind(Some("adv"), Some("camp"))
+    }
+  }
+
+  "an impression token binding camp/adv/cpm" should {
+    val camp = Some("camp-legit")
+    val adv = Some("adv-legit")
+    val cpm = Some("2.5")
+    val rid = Some("01H0RID")
+    val good = impToken(camp, adv, cpm, rid)
+
+    "verify against the exact same fields" in {
+      Signer.safeEq(good, impToken(camp, adv, cpm, rid)) shouldBe true
+    }
+
+    "reject a campaign rewrite (spend redirection to a competitor)" in {
+      Signer.safeEq(good, impToken(Some("camp-victim"), adv, cpm, rid)) shouldBe false
+    }
+
+    "reject an advertiser rewrite" in {
+      Signer.safeEq(good, impToken(camp, Some("adv-victim"), cpm, rid)) shouldBe false
+    }
+
+    "reject a cpm inflation" in {
+      Signer.safeEq(good, impToken(camp, adv, Some("999999"), rid)) shouldBe false
+    }
+
+    "reject dropping camp/adv/cpm entirely" in {
+      Signer.safeEq(good, impToken(None, None, None, rid)) shouldBe false
+    }
+  }
+
+  "Signer.safeEq" should {
+    "be false for unequal lengths without leaking via early return" in {
+      Signer.safeEq("abc", "abcd") shouldBe false
+    }
+    "be true for identical strings" in {
+      Signer.safeEq("abcdef", "abcdef") shouldBe true
+    }
+  }
+}

--- a/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/common/SignerSpec.scala
@@ -36,15 +36,30 @@ class SignerSpec extends AnyWordSpec with Matchers {
     )
 
   "Signer.bind" should {
-    "render present fields as |value in order and skip absent ones" in {
-      Signer.bind(Some("a"), Some("b"), Some("c")) shouldBe "|a|b|c"
-      Signer.bind(Some("a"), None, Some("c")) shouldBe "|a|c"
-      Signer.bind(None, None, None) shouldBe ""
+    "render present fields as |=value and absent ones as a bare separator" in {
+      Signer.bind(Some("a"), Some("b"), Some("c")) shouldBe "|=a|=b|=c"
+      Signer.bind(Some("a"), None, Some("c")) shouldBe "|=a||=c"
+      Signer.bind(None, None, None) shouldBe "|||"
     }
 
     "be order-sensitive so a field swap changes the string" in {
       Signer.bind(Some("camp"), Some("adv")) should not be
         Signer.bind(Some("adv"), Some("camp"))
+    }
+
+    "be injective: a value containing the delimiter cannot emulate two fields" in {
+      // Without URL-encoding, camp="c|a" (adv absent) rendered identically to
+      // camp="c", adv="a" — letting a client shift bytes across field
+      // boundaries on the beacon. The encoding forbids literal `|` in values.
+      Signer.bind(Some("c|a"), None) should not be Signer.bind(Some("c"), Some("a"))
+    }
+
+    "be injective: shifting a value into a neighbouring absent slot changes the string" in {
+      Signer.bind(Some("x"), None) should not be Signer.bind(None, Some("x"))
+    }
+
+    "distinguish an absent field from an empty one" in {
+      Signer.bind(Some("")) should not be Signer.bind(None)
     }
   }
 

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerBatchAssignSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerBatchAssignSpec.scala
@@ -106,16 +106,19 @@ class AdServerBatchAssignSpec extends AnyWordSpec with Matchers {
       // dimensions don't gate selection — so the billboard (largest) slot
       // gets first pick and takes the highest-scoring candidate (rect,
       // cpm 3.0), leaving the smaller rect slot the leftover (billboard,
-      // cpm 2.0). Validates the area-descending pick order.
+      // cpm 2.0). Validates the area-descending pick order. Identical
+      // warm stats give both candidates a tight posterior, so score
+      // ordering follows CPM instead of the cold-start sampling lottery.
       val billboard = candidate("bb", "c1", 970, 250, cpm = 2.0)
       val rect = candidate("mr", "c2", 300, 250, cpm = 3.0)
+      val warm = CreativeStats(buckets = Map(0L -> (10000, 500, 500)))
       val outcomes = AdServer.batchAssign(
         view = view(billboard, rect),
         slots = Vector(slot("rect", 300, 250), slot("billboard", 970, 250)),
         siteFloor = CPM(0.5),
         pageWinners = Set.empty,
         alpha = 0.5,
-        stats = Map.empty,
+        stats = Map(CreativeId("bb") -> warm, CreativeId("mr") -> warm),
         rng = rng()
       )
       val byId = outcomes.map(o => o.slotId.value -> o.winner.map(_.creativeId.value)).toMap

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeAccountingSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeAccountingSpec.scala
@@ -2,8 +2,8 @@ package promovolve.publisher.delivery
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import promovolve.{ AdvertiserId, CampaignId, CategoryId, CPM, CreativeId, SlotId }
-import promovolve.publisher.{ CandidateView, CDNPath, MimeType }
+import promovolve.{ AdvertiserId, CPM, CampaignId, CategoryId, CreativeId, SlotId }
+import promovolve.publisher.{ CDNPath, CandidateView, MimeType }
 import promovolve.publisher.delivery.Protocol.{ BatchSlotOutcome, DogearOutcome }
 
 /**

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeAccountingSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeAccountingSpec.scala
@@ -1,0 +1,107 @@
+package promovolve.publisher.delivery
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import promovolve.{ AdvertiserId, CampaignId, CategoryId, CPM, CreativeId, SlotId }
+import promovolve.publisher.{ CandidateView, CDNPath, MimeType }
+import promovolve.publisher.delivery.Protocol.{ BatchSlotOutcome, DogearOutcome }
+
+/**
+ * Pure tests for the batch serve path's accounting helpers, extracted so the
+ * two behaviors this branch fixes are pinned without spinning up the actor:
+ *
+ *  - `impressedCreatives` — which served winners record a per-creative
+ *    impression: every filled slot EXCEPT honored dog-ear pins. Regression for
+ *    the dead-Thompson bug (the batch path — the only production serve path —
+ *    never recorded impressions, so every creative scored cold forever).
+ *  - `reclassifyInMs` — the freshness token honours the publisher's
+ *    content-recency window. Regression for the window once hardcoded to 0
+ *    downstream, which silently forced the 48h default.
+ */
+class AdServerServeAccountingSpec extends AnyWordSpec with Matchers {
+
+  private def cand(cid: String): CandidateView =
+    CandidateView(
+      creativeId = CreativeId(cid),
+      campaignId = CampaignId(s"camp-$cid"),
+      advertiserId = AdvertiserId(s"adv-$cid"),
+      assetUrl = CDNPath(s"/assets/$cid.png"),
+      mime = MimeType.imagePng,
+      width = 300,
+      height = 250,
+      category = CategoryId("cat-test"),
+      cpm = CPM(1.0),
+      classifiedAtMs = 0L,
+      categoryScore = 0.5
+    )
+
+  private def slot(
+      id: String,
+      winner: Option[String],
+      honoredPin: Boolean = false,
+      dogear: Boolean = false
+  ): BatchSlotOutcome =
+    BatchSlotOutcome(
+      slotId = SlotId(id),
+      winner = winner.map(cand),
+      dogear = if (dogear || honoredPin) Some(DogearOutcome(honored = honoredPin)) else None
+    )
+
+  "AdServer.impressedCreatives" should {
+    "impress every filled slot's winner" in {
+      val outcomes = Vector(slot("s1", Some("a")), slot("s2", Some("b")))
+      AdServer.impressedCreatives(outcomes) shouldBe Vector(CreativeId("a"), CreativeId("b"))
+    }
+
+    "skip unfilled slots (winner = None)" in {
+      val outcomes = Vector(slot("s1", None), slot("s2", Some("b")))
+      AdServer.impressedCreatives(outcomes) shouldBe Vector(CreativeId("b"))
+    }
+
+    "NOT impress an honored dog-ear pin (it stays learning-silent)" in {
+      // A pin re-encounter that was honored must not teach CTR — matches the
+      // billing/CTR treatment in LearningEventLog.
+      val outcomes = Vector(slot("s1", Some("pinned"), honoredPin = true), slot("s2", Some("normal")))
+      AdServer.impressedCreatives(outcomes) shouldBe Vector(CreativeId("normal"))
+    }
+
+    "impress a winner whose dog-ear fell through (honored = false)" in {
+      val outcomes = Vector(slot("s1", Some("a"), dogear = true)) // DogearOutcome(honored = false)
+      AdServer.impressedCreatives(outcomes) shouldBe Vector(CreativeId("a"))
+    }
+
+    "be empty when nothing filled" in {
+      AdServer.impressedCreatives(Vector(slot("s1", None))) shouldBe empty
+    }
+  }
+
+  "AdServer.reclassifyInMs" should {
+    val now = 1_000_000_000_000L
+    val oneHour = 3600000L
+
+    "return 0 for a never-classified page (cold)" in {
+      AdServer.reclassifyInMs(classifiedAtMs = None, recencyWindowMs = oneHour, now = now) shouldBe 0L
+    }
+
+    "be > 0 (fresh) when classified within the recency window" in {
+      // classified 10 min ago, window 1h → ~50 min of freshness left.
+      AdServer.reclassifyInMs(Some(now - 600000L), recencyWindowMs = oneHour, now = now) should be > 0L
+    }
+
+    "be <= 0 (stale) when classified longer ago than the recency window" in {
+      // classified 2h ago, window 1h → aged out.
+      AdServer.reclassifyInMs(Some(now - 2 * oneHour), recencyWindowMs = oneHour, now = now) should be <= 0L
+    }
+
+    "respect the publisher's recency window, not the 48h default (the threading fix)" in {
+      // Regression: the window was hardcoded to 0 downstream, so a page
+      // classified 3h ago read as fresh under the 48h default. With the
+      // publisher's 1h window threaded through it is correctly stale — and
+      // window = 0 still falls back to the 48h default (the old behaviour),
+      // proving the value actually flows.
+      val threeHoursAgo = now - 3 * oneHour
+      AdServer.reclassifyInMs(Some(threeHoursAgo), recencyWindowMs = oneHour, now = now) should be <= 0L
+      AdServer.reclassifyInMs(Some(threeHoursAgo), recencyWindowMs = 0L, now = now) should be > 0L
+    }
+  }
+}

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/PerCategoryClearingSim.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/PerCategoryClearingSim.scala
@@ -27,7 +27,7 @@ class PerCategoryClearingSim extends AnyWordSpec with Matchers {
   /**
    * One bidder in the pooled slot auction. `ctr` stands in for the
    * engagement term; in prod pricing uses the posterior-MEAN engagement
-   * (`CandidateScore.engagement` / `meanScore`) — irrelevant to the
+   * (`CandidateScore.meanEngagement` / `meanScore`) — irrelevant to the
    * PRICING question, which is deterministic given scores.
    */
   private final case class Bid(category: String, cpm: Double, ctr: Double)

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/PerCategoryClearingSim.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/PerCategoryClearingSim.scala
@@ -25,9 +25,10 @@ import promovolve.CPM
 class PerCategoryClearingSim extends AnyWordSpec with Matchers {
 
   /**
-   * One bidder in the pooled slot auction. `ctr` is the (here fixed)
-   * sampled CTR; in prod it comes from the Beta posterior — irrelevant to
-   * the PRICING question, which is deterministic given scores.
+   * One bidder in the pooled slot auction. `ctr` stands in for the
+   * engagement term; in prod pricing uses the posterior-MEAN engagement
+   * (`CandidateScore.engagement` / `meanScore`) — irrelevant to the
+   * PRICING question, which is deterministic given scores.
    */
   private final case class Bid(category: String, cpm: Double, ctr: Double)
 
@@ -43,7 +44,7 @@ class PerCategoryClearingSim extends AnyWordSpec with Matchers {
     val winner = sorted.head
     val bestLoser = if (sorted.size > 1) scoreOf(sorted(1), alpha) else 0.0
     val clearing = ThompsonSampling.qualityAdjustedClearing(
-      winnerSampledCtr = winner.ctr,
+      winnerEngagement = winner.ctr,
       winnerBid = CPM(winner.cpm),
       bestLoserScore = bestLoser,
       alpha = alpha,
@@ -64,7 +65,7 @@ class PerCategoryClearingSim extends AnyWordSpec with Matchers {
       .collectFirst { case b if b.category == winner.category => scoreOf(b, alpha) }
       .getOrElse(0.0)
     val clearing = ThompsonSampling.qualityAdjustedClearing(
-      winnerSampledCtr = winner.ctr,
+      winnerEngagement = winner.ctr,
       winnerBid = CPM(winner.cpm),
       bestLoserScore = bestLoser,
       alpha = alpha,

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/QualityAdjustedClearingSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/QualityAdjustedClearingSpec.scala
@@ -7,13 +7,17 @@ import promovolve.CPM
 /**
  * Pure-function tests for `ThompsonSampling.qualityAdjustedClearing`.
  *
- * The formula inverts `score = sampledCTR × CPM^α` against the
- * runner-up's score, then clamps to [siteFloor, winnerBid]:
+ * The formula inverts `score = engagement × CPM^α` against the
+ * runner-up's posterior-mean score, then clamps to [siteFloor, winnerBid]:
  *
- *   clearingCpm = (bestLoserScore / winnerSampledCtr) ^ (1/α)
+ *   clearingCpm = (bestLoserScore / winnerEngagement) ^ (1/α)
  *
  * Tests below pin the canonical edge cases so future refactors
- * can't silently regress to first-price clearing.
+ * can't silently regress to first-price clearing, plus the
+ * sample-for-allocation / price-on-means contract: clearing prices
+ * are deterministic given the auction state and price the winner on
+ * its FULL mean engagement (ctr + fold + newcomer bonus), not its
+ * CTR alone.
  */
 class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
 
@@ -23,7 +27,7 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
 
     "fall back to siteFloor when there is no runner-up (bestLoserScore = 0)" in {
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.05,
+        winnerEngagement = 0.05,
         winnerBid = CPM(5.0),
         bestLoserScore = 0.0,
         alpha = 0.5,
@@ -32,9 +36,9 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
       clearing shouldBe Floor
     }
 
-    "fall back to siteFloor when winner's sampled CTR is zero" in {
+    "fall back to siteFloor when winner's engagement is zero" in {
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.0,
+        winnerEngagement = 0.0,
         winnerBid = CPM(5.0),
         bestLoserScore = 0.5,
         alpha = 0.5,
@@ -45,7 +49,7 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
 
     "fall back to siteFloor when alpha is non-positive" in {
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.05,
+        winnerEngagement = 0.05,
         winnerBid = CPM(5.0),
         bestLoserScore = 0.5,
         alpha = 0.0,
@@ -55,12 +59,12 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
     }
 
     "compute the inverse-score formula at α=0.5 (sqrt)" in {
-      // Winner: sampledCtr=0.04, bid=$5.00 → score = 0.04 × √5 ≈ 0.0894
+      // Winner: engagement=0.04, bid=$5.00 → score = 0.04 × √5 ≈ 0.0894
       // Runner-up score: 0.0500
       // clearingCpm = (0.05 / 0.04)^2 = 1.25^2 = 1.5625
       // Within [floor=0.5, bid=5.0] → 1.5625
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.04,
+        winnerEngagement = 0.04,
         winnerBid = CPM(5.0),
         bestLoserScore = 0.05,
         alpha = 0.5,
@@ -70,11 +74,11 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
     }
 
     "compute the inverse-score formula at α=0.7" in {
-      // Winner: sampledCtr=0.05, bid=$8.00
+      // Winner: engagement=0.05, bid=$8.00
       // Runner-up score: 0.10
       // clearingCpm = (0.10 / 0.05)^(1/0.7) = 2^1.4286 ≈ 2.6918
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.05,
+        winnerEngagement = 0.05,
         winnerBid = CPM(8.0),
         bestLoserScore = 0.10,
         alpha = 0.7,
@@ -87,7 +91,7 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
       // High-CTR winner against a weak runner-up — formula would give
       // a clearing below the floor, but the publisher's floor wins.
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.5,
+        winnerEngagement = 0.5,
         winnerBid = CPM(5.0),
         bestLoserScore = 0.01,
         alpha = 0.5,
@@ -98,17 +102,108 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
 
     "clamp DOWN to winner's bid when the formula yields a price above it" in {
       // Pathological: a runner-up score so high relative to the
-      // winner's CTR that the formula would have the winner pay more
-      // than they bid. Cap at the bid — the campaign never owes more
-      // than its max CPM.
+      // winner's engagement that the formula would have the winner pay
+      // more than they bid. Cap at the bid — the campaign never owes
+      // more than its max CPM.
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerSampledCtr = 0.001,
+        winnerEngagement = 0.001,
         winnerBid = CPM(2.0),
         bestLoserScore = 1.0,
         alpha = 0.5,
         siteFloor = Floor
       )
       clearing shouldBe CPM(2.0)
+    }
+  }
+
+  "sample-for-allocation / price-on-means" should {
+
+    import promovolve.publisher.{ CDNPath, CandidateView, MimeType }
+    import promovolve.{ AdvertiserId, CampaignId, CategoryId, CreativeId }
+    import promovolve.publisher.delivery.Protocol.CreativeStats
+
+    val Alpha = 0.5
+
+    def cand(cid: String, cpm: Double, categoryScore: Double = 0.5): CandidateView =
+      CandidateView(
+        creativeId = CreativeId(cid),
+        campaignId = CampaignId(s"camp-$cid"),
+        advertiserId = AdvertiserId(s"adv-$cid"),
+        assetUrl = CDNPath(s"/assets/$cid.png"),
+        mime = MimeType.imagePng,
+        width = 300,
+        height = 250,
+        category = CategoryId("cat-test"),
+        cpm = CPM(cpm),
+        classifiedAtMs = 0L,
+        categoryScore = categoryScore
+      )
+
+    def warmStats(impressions: Int, clicks: Int, folds: Int): CreativeStats =
+      CreativeStats(buckets = Map(0L -> (impressions, clicks, folds)))
+
+    "price against the runner-up's mean score and the winner's FULL mean engagement" in {
+      // Regression for the CTR-only denominator bug: the loser's price-
+      // setting score included fold + bonus while the winner's denominator
+      // was its sampled CTR alone, so the winner systematically overpaid.
+      // Expected clearing derives from the engagement-based inversion:
+      //   clearing = (loser.meanScore / winner.engagement)^(1/α)
+      val winner = cand("w", cpm = 5.0)
+      val loser = cand("l", cpm = 4.0)
+      // Past the newcomer decay window so bonus = 0 and means are pure posteriors.
+      val ws = ThompsonSampling.scoreCandidate(winner, warmStats(1000, 100, 100), new scala.util.Random(7L), Alpha)
+      val ls = ThompsonSampling.scoreCandidate(loser, warmStats(1000, 60, 60), new scala.util.Random(7L), Alpha)
+
+      // Closed-form posterior means:
+      //   engagement = (clicks+1)/(imps+2) + FoldWeight × (folds+1)/(imps+2)
+      val fw = ThompsonSampling.FoldWeight
+      ws.engagement shouldBe (101.0 / 1002.0) * (1.0 + fw) +- 1e-12
+      ls.meanScore shouldBe (61.0 / 1002.0) * (1.0 + fw) * math.pow(4.0, Alpha) +- 1e-12
+
+      val clearing = ThompsonSampling.qualityAdjustedClearing(
+        winnerEngagement = ws.engagement,
+        winnerBid = winner.cpm,
+        bestLoserScore = ls.meanScore,
+        alpha = Alpha,
+        siteFloor = Floor
+      )
+      val expected = math.pow(ls.meanScore / ws.engagement, 1.0 / Alpha)
+      // Strictly inside (floor, bid) so neither clamp hides the formula.
+      expected should be > Floor.toDouble
+      expected should be < winner.cpm.toDouble
+      clearing.toDouble shouldBe expected +- 1e-9
+    }
+
+    "produce the same clearing price for the same auction state regardless of RNG draws" in {
+      // Selection samples (scores differ per request); pricing must not —
+      // engagement / meanScore are posterior means, so two requests over
+      // identical stats clear at the identical price. Covers cold AND warm.
+      val winner = cand("w", cpm = 5.0, categoryScore = 0.5) // cold
+      val loser = cand("l", cpm = 4.0)
+      val loserStats = warmStats(200, 10, 8)
+      def clearingWith(seed: Long): (Double, Double, Double) = {
+        val rng = new scala.util.Random(seed)
+        val ws = ThompsonSampling.scoreCandidate(winner, CreativeStats(), rng, Alpha)
+        val ls = ThompsonSampling.scoreCandidate(loser, loserStats, rng, Alpha)
+        val c = ThompsonSampling.qualityAdjustedClearing(
+          winnerEngagement = ws.engagement,
+          winnerBid = winner.cpm,
+          bestLoserScore = ls.meanScore,
+          alpha = Alpha,
+          siteFloor = Floor
+        )
+        (ws.engagement, ls.meanScore, c.toDouble)
+      }
+      val (e1, m1, c1) = clearingWith(1L)
+      val (e2, m2, c2) = clearingWith(999L)
+      e1 shouldBe e2
+      m1 shouldBe m2
+      c1 shouldBe c2
+      // Cold mean engagement documents the pricing prior: categoryScore
+      // + FoldWeight × Beta(1,3)-mean + full newcomer bonus.
+      val coldFoldMean = ThompsonSampling.ColdFoldPriorAlpha /
+        (ThompsonSampling.ColdFoldPriorAlpha + ThompsonSampling.ColdFoldPriorBeta)
+      e1 shouldBe 0.5 + ThompsonSampling.FoldWeight * coldFoldMean + ThompsonSampling.NewcomerBoost +- 1e-12
     }
   }
 
@@ -150,11 +245,10 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
     def alwaysReserve: (CandidateView, CPM, String) => Future[Boolean] = (_, _, _) => Future.successful(true)
 
     "clear below the winner's bid when there is a runner-up" in {
-      // Two cold candidates compete for one slot. With seeded RNG and
-      // identical Beta(1,1) priors, sampledCtr for both is in [0,1];
-      // winner's score must beat runner-up's score, so the formula
-      // produces a clearingPrice strictly less than the winner's bid
-      // and at or above the floor.
+      // Two cold candidates compete for one slot. Both carry identical
+      // cold priors, so the price-setting mean scores differ only by
+      // CPM; the formula produces a clearingPrice at most the winner's
+      // bid and at or above the floor.
       val c1 = candidate("c1", "campA", 300, 250, cpm = 5.0)
       val c2 = candidate("c2", "campB", 300, 250, cpm = 4.0)
       import FuturesHelper.given

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/QualityAdjustedClearingSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/QualityAdjustedClearingSpec.scala
@@ -147,7 +147,7 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
       // setting score included fold + bonus while the winner's denominator
       // was its sampled CTR alone, so the winner systematically overpaid.
       // Expected clearing derives from the engagement-based inversion:
-      //   clearing = (loser.meanScore / winner.engagement)^(1/α)
+      //   clearing = (loser.meanScore / winner.meanEngagement)^(1/α)
       val winner = cand("w", cpm = 5.0)
       val loser = cand("l", cpm = 4.0)
       // Past the newcomer decay window so bonus = 0 and means are pure posteriors.
@@ -157,17 +157,17 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
       // Closed-form posterior means:
       //   engagement = (clicks+1)/(imps+2) + FoldWeight × (folds+1)/(imps+2)
       val fw = ThompsonSampling.FoldWeight
-      ws.engagement shouldBe (101.0 / 1002.0) * (1.0 + fw) +- 1e-12
+      ws.meanEngagement shouldBe (101.0 / 1002.0) * (1.0 + fw) +- 1e-12
       ls.meanScore shouldBe (61.0 / 1002.0) * (1.0 + fw) * math.pow(4.0, Alpha) +- 1e-12
 
       val clearing = ThompsonSampling.qualityAdjustedClearing(
-        winnerEngagement = ws.engagement,
+        winnerEngagement = ws.meanEngagement,
         winnerBid = winner.cpm,
         bestLoserScore = ls.meanScore,
         alpha = Alpha,
         siteFloor = Floor
       )
-      val expected = math.pow(ls.meanScore / ws.engagement, 1.0 / Alpha)
+      val expected = math.pow(ls.meanScore / ws.meanEngagement, 1.0 / Alpha)
       // Strictly inside (floor, bid) so neither clamp hides the formula.
       expected should be > Floor.toDouble
       expected should be < winner.cpm.toDouble
@@ -176,7 +176,7 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
 
     "produce the same clearing price for the same auction state regardless of RNG draws" in {
       // Selection samples (scores differ per request); pricing must not —
-      // engagement / meanScore are posterior means, so two requests over
+      // meanEngagement / meanScore are posterior means, so two requests over
       // identical stats clear at the identical price. Covers cold AND warm.
       val winner = cand("w", cpm = 5.0, categoryScore = 0.5) // cold
       val loser = cand("l", cpm = 4.0)
@@ -186,13 +186,13 @@ class QualityAdjustedClearingSpec extends AnyWordSpec with Matchers {
         val ws = ThompsonSampling.scoreCandidate(winner, CreativeStats(), rng, Alpha)
         val ls = ThompsonSampling.scoreCandidate(loser, loserStats, rng, Alpha)
         val c = ThompsonSampling.qualityAdjustedClearing(
-          winnerEngagement = ws.engagement,
+          winnerEngagement = ws.meanEngagement,
           winnerBid = winner.cpm,
           bestLoserScore = ls.meanScore,
           alpha = Alpha,
           siteFloor = Floor
         )
-        (ws.engagement, ls.meanScore, c.toDouble)
+        (ws.meanEngagement, ls.meanScore, c.toDouble)
       }
       val (e1, m1, c1) = clearingWith(1L)
       val (e2, m2, c2) = clearingWith(999L)

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/ThompsonSamplingSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/ThompsonSamplingSpec.scala
@@ -51,7 +51,8 @@ class ThompsonSamplingSpec extends AnyWordSpec with Matchers {
 
     "use the cold-start category prior when impressions == 0" in {
       // CTR derives from categoryScore + jitter; fold-rate samples from
-      // Beta(1,1) so cold creatives have a real fold component (not 0).
+      // the Beta(1,3) cold prior so cold creatives have a real fold
+      // component (not 0) without dominating warm ones.
       val cold = stats(impressions = 0, clicks = 0, folds = 0)
       val rng = new scala.util.Random(42L)
       val s = ThompsonSampling.scoreCandidate(candidate(cpm = 1.0), cold, rng, alpha = 0.5)
@@ -77,28 +78,23 @@ class ThompsonSamplingSpec extends AnyWordSpec with Matchers {
       avg(draws(midDecay)) should be > avg(draws(warm))
     }
 
-    // TODO: references ThompsonSampling.newcomerBonus / NewcomerDecayImpressions
-    // / NewcomerBoost which no longer exist on the object (removed in an
-    // earlier unrelated refactor). Skipped here so the spec compiles;
-    // restore once the newcomer-boost API is settled or this assertion
-    // is rewritten against the current API.
-    "stop boosting once impressions reach the decay window" ignore {
+    "stop boosting once impressions reach the decay window" in {
       // Past NewcomerDecayImpressions the bonus must read zero so the
       // creative is competing purely on its Beta posteriors.
-      // ThompsonSampling.newcomerBonus(0) shouldBe ThompsonSampling.NewcomerBoost
-      // ThompsonSampling.newcomerBonus(ThompsonSampling.NewcomerDecayImpressions) shouldBe 0.0
-      // ThompsonSampling.newcomerBonus(ThompsonSampling.NewcomerDecayImpressions * 10) shouldBe 0.0
+      ThompsonSampling.newcomerBonus(0) shouldBe ThompsonSampling.NewcomerBoost
+      ThompsonSampling.newcomerBonus(ThompsonSampling.NewcomerDecayImpressions) shouldBe 0.0
+      ThompsonSampling.newcomerBonus(ThompsonSampling.NewcomerDecayImpressions * 10) shouldBe 0.0
     }
 
     "let cold creatives compete with warm fold-rich ones" in {
       // Regression: previously cold creatives' foldComponent was hard-
       // coded to 0, so a warm creative with even moderate fold rate
       // dominated cold candidates and newly introduced creatives could
-      // never win. With Beta(1,1) cold-start fold sampling, cold
-      // creatives draw from Uniform[0,1] and routinely produce a
-      // foldComponent up to FoldWeight, making them genuinely
-      // competitive. Distributional check: cold creatives' average
-      // engagement should sit above the warm fold-rich ceiling.
+      // never win. With the Beta(1,3) cold-start fold prior plus the
+      // newcomer bonus, cold creatives routinely produce a competitive
+      // fold component without hijacking the slot outright.
+      // Distributional check: cold creatives' average engagement should
+      // sit above the warm fold-rich ceiling.
       val cold = stats(impressions = 0, clicks = 0, folds = 0)
       val warmFoldRich = stats(impressions = 100, clicks = 5, folds = 30)
       val rng = new scala.util.Random(0L)
@@ -140,6 +136,39 @@ class ThompsonSamplingSpec extends AnyWordSpec with Matchers {
         ThompsonSampling.scoreCandidate(candidate(cpm = 1.0), noFolds, rng, alpha = 0.5).score
       )
       avg(a) should be > avg(b)
+    }
+
+    "clamp the cold-start sampled CTR at a small positive value" in {
+      // A low categoryScore minus the ±0.15 jitter used to go negative,
+      // letting a creative win purely on its fold draw while its CTR
+      // sample was < 0. The clamp keeps every cold CTR sample ≥ 0.001.
+      val cold = stats(impressions = 0, clicks = 0, folds = 0)
+      val rng = new scala.util.Random(0L)
+      val samples = (1 to 1000).map(_ =>
+        ThompsonSampling.scoreCandidate(candidate(cpm = 1.0, categoryScore = 0.0), cold, rng, alpha = 0.5).sampledCtr
+      )
+      all(samples) should be >= 0.001
+    }
+
+    "tighten the cold fold prior to Beta(1,3) so cold creatives don't dominate outright" in {
+      // With the old Beta(1,1) prior the cold fold component averaged
+      // FoldWeight × 0.5 = 1.0 and a new creative won near-
+      // deterministically. Beta(1,3) pulls the cold mean engagement to
+      // catScore + FoldWeight×0.25 + NewcomerBoost. Distributional
+      // check: at cpm=1/α=0.5 the average cold score must sit near that
+      // mean (≈1.5 at catScore=0.5), well below the ≈2.0 the uniform
+      // prior produced.
+      val cold = stats(impressions = 0, clicks = 0, folds = 0)
+      val rng = new scala.util.Random(0L)
+      val avgScore = avg((1 to 2000).map(_ =>
+        ThompsonSampling.scoreCandidate(candidate(cpm = 1.0, categoryScore = 0.5), cold, rng, alpha = 0.5).score
+      ))
+      val expectedMean = 0.5 +
+        ThompsonSampling.FoldWeight * ThompsonSampling.ColdFoldPriorAlpha /
+        (ThompsonSampling.ColdFoldPriorAlpha + ThompsonSampling.ColdFoldPriorBeta) +
+        ThompsonSampling.NewcomerBoost
+      avgScore shouldBe expectedMean +- 0.05
+      avgScore should be < 1.7 // the uniform-prior mean was 2.0
     }
 
     "stamp the fold posterior shape into debugInfo for warm creatives" in {


### PR DESCRIPTION
## Summary

Five delivery/tracking fixes on this branch — three primary defects plus two review follow-ups.

### Auction pricing on posterior means (630eaaf)

- **Clearing-formula inversion bug:** `qualityAdjustedClearing` divided the runner-up's *full* engagement-based score (fold posterior + newcomer bonus included) by the winner's *sampled CTR alone*, so winners systematically overpaid — a cold winner's price almost always clamped to its bid, i.e. de-facto first price. Pricing now inverts the same engagement formula on both sides.
- **Deterministic pricing:** `CandidateScore` now carries the engagement/score evaluated at the posterior **means**. Selection keeps its Thompson exploration; pricing is reproducible from observable state — same auction state, same clearing price.
- **Cold-start fold prior too strong:** cold fold sampling tightened from `Beta(1,1)` (expected fold component 1.0) to `Beta(1,3)` (0.5), so newly introduced creatives explore without hijacking slots near-deterministically.
- **Negative cold CTR sample:** cold CTR clamped at `max(0.001, categoryScore + jitter)`.

### Beacon HMAC binding (acbfeb1, hardened in 075cea1)

- Tracking tokens signed only `pub|url|slot|cid|ver|bucket|evt(+rid)`; `camp`/`adv`/`cpm` rode the beacon URL **unsigned**. One valid serve token could be replayed with `&camp=<victim>&adv=<victim>&cpm=999999`, landing forged spend on an arbitrary competitor's daily budget. Now bound into the HMAC at mint (`ServeRoutes.signedUrl`) and re-verified at beacon time (`TrackRoutes`).
- Follow-up (075cea1): `Signer.bind` originally skipped absent fields and joined raw values with a bare pipe, so the rendering was ambiguous (`camp="c|a"` signed identically to `camp="c", adv="a"`). Now every field emits its own separator, values are URL-encoded, and `Some("")` is distinguished from `None` — injective for a fixed arity.
- **Deploy note:** previously issued tokens are rejected after deploy; tokens are short-lived (freshBucket window) so the gap is minutes.

### Delivery-layer defects (562bb07, follow-ups in 81d0c59)

- **Impressions never recorded on the live serve path:** the batch handler (the only production serve path) never touched `creativeStats`, so every creative scored through the cold branch forever and Thompson Sampling was effectively dead. `BatchReservationsResolved` now records a per-creative impression for each served winner (honored pins stay learning-silent).
- **Approval revocation over-scoped:** pausing/evicting one campaign stripped in-memory approvals via the slot-key index, which conflates every campaign sharing a slot key — co-tenant campaigns' approvals were revoked too (memory/DB divergence, spurious re-queue, voided reader pins). Now resolves the campaign's OWN creatives from the approvals store via the new `CampaignApprovalsRevoked` internal command.
- **Recency window discarded:** `BatchSelect.contentRecencyWindowMs` was hardcoded to `0L` downstream, so the recency filter never ran and `BatchContentTooOld` was unreachable. Real value threaded through. **Deploy note:** this activates a previously-dead filter — publishers on the 48h default may see stale-classified pages drop candidates and trigger reclassification right after deploy.
- Follow-ups (81d0c59): revocation DB-load failures are now logged instead of silently skipping the revocation; `CandidateScore.engagement` renamed to `meanEngagement` (it holds the posterior mean, not a draw); stale `LearningEventLog` docs fixed.

## Test plan

- New `SignerSpec` pins the tamper-rejection contract (campaign/advertiser/cpm rewrites rejected) and the `bind` injectivity properties (delimiter injection, field-boundary shifts, empty-vs-absent).
- New regression tests in `QualityAdjustedClearingSpec`: closed-form engagement-based inversion and RNG-independence of clearing prices.
- New tests in `ThompsonSamplingSpec`: cold CTR clamp, cold mean-engagement pinned to the `Beta(1,3)` closed form; re-enabled the previously-ignored newcomer-decay test.
- All touched suites pass: 6 core suites (53 tests) + full `api` module (76 tests). Remaining full `core/test` failures are pre-existing on the base commit (verified via stash: learning-sim tolerance, BloomFilter perf threshold, Pekko sharding init race, config NPE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)