### PR TITLE
cleanup: drop RL vestiges; serve stats price at clearing, not bid

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1293,14 +1293,13 @@ floors layer on top of it, tuned automatically by a direct sweep optimizer.
 1. Admin override        (publisher escape hatch — adminSlotFloorOverrides,
                           or an override carried on the slot spec via the
                           classify-page path; always wins)
-2. Sweep-learned override (learned per-slot floor — slotFloorOverrides)
-3. (Per-category floor, else site floor) × slot-prior scaling
+2. (Per-category floor, else site floor) × slot-prior scaling
                           — SlotPrior: floor × (0.5 + qualityScore), a
                             0.5×–1.5× band. The prior is measured by the AD
                             TAG in the visitor's real viewport (above-fold,
                             viewability, region, text density) — the crawler
                             that used to produce it is gone
-4. Site floor            (fallback — the base floor-cpm above)
+3. Site floor            (fallback — the base floor-cpm above)
 ```
 
 **FloorSweepOptimizer — the sole floor mechanism.** The former DQN agent was
@@ -1342,11 +1341,16 @@ bid — winning is how they reach the approval queue — but their bids never
 teach the floor: a pending bid must not peg a reserve that nothing servable
 can fulfil.
 
-`SiteEntity` emits two per-slot messages to its `AuctioneerEntity`:
+`SiteEntity` emits one per-slot message to its `AuctioneerEntity`:
 
-- `UpdateSlotFloors(Map[SlotId, CPM])` — sweep-learned per-slot overrides.
 - `UpdateAdminSlotFloors(Map[SlotId, CPM])` — the publisher escape hatch; a
-  manually pinned floor that always wins over the learned value.
+  manually pinned floor that always wins over the learned site/category floor.
+
+There is no learned *per-slot* floor. The sweep optimizer learns site- and
+category-level floors only; per-slot variation comes from the slot prior and
+the admin override. (`UpdateSlotFloors`, a leftover hook from the removed RL
+agent, was deleted 2026-07-27 — it had no producer and its handler only ever
+wrote an always-empty map.)
 
 Floor overrides only re-shape the floor; everything else (auction, pacing,
 Thompson Sampling) is unchanged. Note: in a homogeneous market (all bids

--- a/modules/api/src/main/scala/promovolve/api/ApiJsonFormats.scala
+++ b/modules/api/src/main/scala/promovolve/api/ApiJsonFormats.scala
@@ -80,7 +80,7 @@ trait ApiJsonFormats extends DefaultJsonProtocol {
     }
   }
   given RootJsonFormat[SiteList] = jsonFormat2(SiteList.apply)
-  given RootJsonFormat[CreateSiteRequest] = jsonFormat6(CreateSiteRequest.apply)
+  given RootJsonFormat[CreateSiteRequest] = jsonFormat7(CreateSiteRequest.apply)
   given RootJsonFormat[UpdateSiteRequest] = jsonFormat9(UpdateSiteRequest.apply)
   given RootJsonFormat[VerificationTokenResponse] = jsonFormat6(VerificationTokenResponse.apply)
   given RootJsonFormat[VerificationResponse] = jsonFormat3(VerificationResponse.apply)

--- a/modules/api/src/main/scala/promovolve/api/ApiModels.scala
+++ b/modules/api/src/main/scala/promovolve/api/ApiModels.scala
@@ -254,7 +254,7 @@ object ApiModels {
       slotId: String,
       width: Int,
       height: Int,
-      floorOverride: Option[String] = None, // admin escape hatch — overrides RL + prior
+      floorOverride: Option[String] = None, // admin escape hatch — overrides learned floors + prior
       // Crawler-derived prior (read-only, surfaced for UI explainability)
       priorQualityScore: Option[Double] = None,
       priorRegion: Option[String] = None,
@@ -276,8 +276,8 @@ object ApiModels {
       createdAt: String,
       updatedAt: String,
       verificationStatus: String, // unverified, verified
-      floorCpm: String = "0.50", // current floor CPM (auto-optimized by RL)
-      minFloorCpm: String = "0.10", // publisher-set minimum floor
+      floorCpm: String = "0.50", // current floor CPM (auto-optimized by the sweep); real value always supplied
+      minFloorCpm: String = "0.10", // publisher-set minimum floor; real value always supplied
       bidWeight: String = "0.50", // scoring exponent: discovery=0.3, balanced=0.5, revenue=0.7
       // Whether pages with no contextual match route to the filler
       // auction. Default true; flip to false to silence filler
@@ -315,7 +315,13 @@ object ApiModels {
       crawlConfig: SiteCrawlConfig,
       slots: Vector[SiteSlotConfig] = Vector.empty,
       taxonomyIds: Vector[String] = Vector.empty,
-      minFloorCpm: String // Required: publisher must set minimum floor on site creation
+      minFloorCpm: String, // Required: publisher must set minimum floor on site creation
+      // Starting floor for the site, in the deployment's base currency. The
+      // operator sets it at install (a floor that reads right in dollars is
+      // ~157x too low in yen, so there is no cross-currency default worth
+      // shipping). Optional: absent means "use the entity's own seed", which
+      // keeps older platform builds working.
+      floorCpm: Option[String] = None
   )
 
   /**
@@ -325,8 +331,13 @@ object ApiModels {
   case class UpdateSlotFloorRequest(floorCpm: Option[String] = None)
 
   /**
-   * One row in the floor-RL decision log. ISO timestamps + floors as
+   * One row in the floor-sweep decision log. ISO timestamps + floors as
    * strings to keep the JSON inspectable.
+   *
+   * `epsilon` and `trainingLoss` are RL-era names retained as JSON keys
+   * for compatibility: epsilon carries the sweep's remaining-probe
+   * fraction (see FloorSweepOptimizer.epsilon) and trainingLoss is
+   * always None. No learner produces either.
    */
   case class FloorObservationResponse(
       ts: String,
@@ -645,7 +656,7 @@ object ApiModels {
       slots: Option[Vector[SiteSlotConfig]] = None,
       taxonomyIds: Option[Vector[String]] = None,
       floorCpm: Option[String] = None, // override current floor (normally auto-managed)
-      minFloorCpm: Option[String] = None, // publisher minimum floor (RL cannot go below this)
+      minFloorCpm: Option[String] = None, // publisher minimum floor (the sweep cannot go below this)
       bidWeight: Option[String] = None, // scoring exponent: discovery=0.3, balanced=0.5, revenue=0.7
       acceptsFillerTraffic: Option[Boolean] = None // opt in/out of filler auction for this site
   )

--- a/modules/api/src/main/scala/promovolve/api/Endpoints.scala
+++ b/modules/api/src/main/scala/promovolve/api/Endpoints.scala
@@ -315,7 +315,7 @@ object Endpoints extends ApiJsonFormats {
       .tag("Sites")
       .summary("Set or clear per-slot floor override (admin escape hatch)")
       .description(
-        "Per-slot manual floor. Beats RL and prior. Pass floorCpm=null (or omit) to clear and let the slot fall back to RL/prior.")
+        "Per-slot manual floor. Beats every learned floor and the crawler prior. Pass floorCpm=null (or omit) to clear and let the slot fall back to the prior-scaled site floor.")
       .put
       .in(sitesBase / path[String]("siteId") / "slots" / path[String]("slotId") / "floor")
       .in(jsonBody[UpdateSlotFloorRequest])
@@ -325,9 +325,9 @@ object Endpoints extends ApiJsonFormats {
   val getFloorObservations: PublicEndpoint[(String, String, Int), ErrorResponse, RecentFloorObservationsResponse, Any] =
     endpoint
       .tag("Sites")
-      .summary("Get recent floor-RL decisions for a site")
+      .summary("Get recent floor-sweep decisions for a site")
       .description(
-        "Returns the in-memory ring buffer of recent observation windows (most-recent first). Each entry shows what the floor-CPM agent did or skipped that window. Not persisted; available only while the SiteEntity actor is running.")
+        "Returns the ring buffer of recent observation windows (most-recent first). Each entry shows what the floor-CPM sweep optimizer did or skipped that window. Persisted with the site, so entries survive an api-pod restart.")
       .get
       .in(sitesBase / path[String]("siteId") / "floor-observations")
       .in(query[Int]("limit").default(100))
@@ -563,9 +563,9 @@ object Endpoints extends ApiJsonFormats {
   val resetFloorAgent: PublicEndpoint[(String, String), ErrorResponse, Unit, Any] =
     endpoint
       .tag("Sites")
-      .summary("Reset the floor-RL agent for a site (admin escape hatch)")
+      .summary("Reset the floor-sweep optimizer for a site (admin escape hatch)")
       .description(
-        "Wipes the persisted agent snapshot and force-reloads the shipped warm-start default. Use when a site's agent has drifted to a pathological state. Logs a warning.")
+        "Wipes the persisted optimizer snapshot and force-reloads the shipped warm-start default. Use when a site's floor has drifted to a pathological state. Logs a warning.")
       .post
       .in(sitesBase / path[String]("siteId") / "reset-floor-agent")
       .out(statusCode(sttp.model.StatusCode.NoContent))

--- a/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
+++ b/modules/api/src/main/scala/promovolve/api/LearningEventLog.scala
@@ -151,7 +151,7 @@ final class LearningEventLog(
         replyTo = system.ignoreRef
       )
 
-      // 5. Notify SiteEntity of served impression for floor CPM optimization RL.
+      // 5. Notify SiteEntity of served impression for floor-CPM sweep optimization.
       //    Tag with the winning creative's category so the per-category floor
       //    optimizer (per-category floors) can attribute revenue; the
       //    site-wide optimizer ignores the tag.

--- a/modules/core/src/main/scala/promovolve/advertiser/CampaignEntity.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/CampaignEntity.scala
@@ -1559,8 +1559,9 @@ object CampaignEntity {
           // Adopt the account timezone in case the advertiser's fan-out tell
           // was lost while this entity was passivated (no-op when unchanged).
           refreshTimezoneFromAdvertiser()
-          // RL disabled — quality-adjusted auction makes bid shading counterproductive.
-          // Bidding true value (maxCPM) is always optimal in Vickrey auction.
+          // No bid shading: the quality-adjusted auction clears at a second
+          // price, so bidding true value (maxCPM) is always optimal and a
+          // shaded bid only loses winnable auctions at no price benefit.
 
           // Initialize ephemeral bloom filter from persisted filter
           ephemeral = EphemeralState.fromPersistedFilter(state.processedFilter)

--- a/modules/core/src/main/scala/promovolve/auction/AUCTION.md
+++ b/modules/core/src/main/scala/promovolve/auction/AUCTION.md
@@ -312,7 +312,7 @@ Behaviors.receiveMessage[Messages] { msg =>
 - `RestoreClassifications` from `SiteEntity` after cluster restart
 - `CampaignChanged` from `CampaignDirectory` via topic
 - `BudgetEvent` subtypes from `CampaignEntity` via topic
-- Floor updates (`UpdateFloorCpm`, `UpdateCategoryFloors`, `UpdateSlotFloors`, `UpdateAdminSlotFloors`) from `SiteEntity`
+- Floor updates (`UpdateFloorCpm`, `UpdateCategoryFloors`, `UpdateAdminSlotFloors`) from `SiteEntity`
 
 ### Outbound
 

--- a/modules/core/src/main/scala/promovolve/auction/AuctioneerEntity.scala
+++ b/modules/core/src/main/scala/promovolve/auction/AuctioneerEntity.scala
@@ -163,18 +163,19 @@ object AuctioneerEntity {
    */
   final case class UpdateCategoryFloors(floors: Map[CategoryId, CPM]) extends Command
 
-  /**
-   * Per-slot floor overrides emitted by the RL agent once a slot
-   * accumulates enough auctions to diverge meaningfully from the
-   * site average. Sent alongside `UpdateFloorCpm`. Slots not in the
-   * map fall through to the site floor (with crawler prior).
-   */
-  final case class UpdateSlotFloors(floors: Map[SlotId, CPM]) extends Command
+  // UpdateSlotFloors (learned per-slot floor multipliers) removed
+  // 2026-07-27: the RL agent that emitted them is gone and the sweep
+  // optimizer produces site- and category-level floors only, so the
+  // command had zero producers and its handler only ever wrote an
+  // always-empty map. Per-slot divergence from the site floor is now
+  // expressed by the crawler prior and the admin override. Don't
+  // reintroduce a learned per-slot floor without a producer.
 
   /**
    * Admin-set per-slot floor overrides (escape hatch for publishers).
-   * Take precedence over RL slot floors. Replaces the full admin map
-   * each call — slots not in the map have no admin override.
+   * The most authoritative per-slot floor there is — nothing learned
+   * competes with it. Replaces the full admin map each call — slots
+   * not in the map have no admin override.
    */
   final case class UpdateAdminSlotFloors(floors: Map[SlotId, CPM]) extends Command
 
@@ -195,7 +196,7 @@ object AuctioneerEntity {
       declaredSizes: List[AdSize],
       computedSize: AdSize,
       // Per-slot floor knobs — see SiteEntity.SlotPrior / effectiveFloor.
-      // prior is crawler-derived; floorOverride is RL/admin-set.
+      // prior is crawler-derived; floorOverride is admin-set.
       // Both default to None so existing call sites compile unchanged
       // and the system falls through to the site-level floor.
       prior: Option[SiteEntity.SlotPrior] = None,
@@ -412,16 +413,6 @@ private final class AuctioneerEntity private (
     case UpdateCategoryFloors(floors) =>
       ctx.log.info("Per-category floors updated: site={} count={}", siteId, floors.size: java.lang.Integer)
       currentCategoryFloors = floors
-      scheduleReauction()
-      Behaviors.same
-
-    case UpdateSlotFloors(floors) =>
-      ctx.log.info(
-        "Per-slot floors updated (RL): site={} count={} floors={}",
-        siteId, floors.size: java.lang.Integer,
-        floors.iterator.map { case (sid, cpm) => f"${sid.value}=$$${cpm.toDouble}%.3f" }.mkString(",")
-      )
-      slotFloorOverrides = floors
       scheduleReauction()
       Behaviors.same
 
@@ -772,7 +763,11 @@ private final class AuctioneerEntity private (
       // Report auction outcome to SiteEntity for floor CPM optimization
       val winnerCpm = topCandidates.headOption.map(_.cpm.toDouble)
       val clearingPrice = topCandidates match {
-        case first +: second +: _ => Some(second.cpm.toDouble + 0.01)
+        // Second price plus the smallest meaningful increment. Relative
+        // rather than a flat cent: a cent is ~1% of a dollar CPM but
+        // ~0.001% of a yen one, so a fixed epsilon stops being an increment
+        // at all once the deployment's currency changes.
+        case first +: second +: _ => Some(second.cpm.toDouble * 1.001)
         case first +: _           => Some(currentFloorCpm.toDouble)
         case _                    => None
       }
@@ -1271,15 +1266,10 @@ private final class AuctioneerEntity private (
   // Per-category floors from SiteEntity. Empty until learned →
   // every category falls back to `currentFloorCpm` (legacy single-floor).
   private var currentCategoryFloors: Map[CategoryId, CPM] = Map.empty
-  // Per-slot floor overrides. Formerly populated by a removed RL agent's
-  // learned per-slot multipliers; the sweep optimizer emits no per-slot
-  // overrides, so this stays empty and the per-slot floor falls through
-  // to the crawler prior / admin override. Retained as a no-op hook
-  // rather than threading a removal through the floor-resolution path.
-  private var slotFloorOverrides: Map[SlotId, CPM] = Map.empty
   // Admin-set per-slot overrides (escape hatch). SiteEntity pushes
   // these on every admin edit and on startup from persisted state.
-  // Take precedence over RL overrides at scoring time.
+  // The only per-slot floor override there is — see the UpdateSlotFloors
+  // removal note above.
   private var adminSlotFloorOverrides: Map[SlotId, CPM] = Map.empty
   // Admin overrides carried on AdSlotSpec (the classify-page path's
   // equivalent source). Recorded at fan-out so finishAuction can resolve
@@ -1317,9 +1307,8 @@ private final class AuctioneerEntity private (
         //   1. Admin override   (publisher escape hatch — adminSlotFloorOverrides)
         //   2. Admin override carried on the AdSlotSpec (path used by
         //      the external classify-page endpoint; equivalent source)
-        //   3. RL-learned override (slotFloorOverrides)
-        //   4. Site floor scaled by crawler prior
-        //   5. Site floor
+        //   3. Site floor scaled by crawler prior
+        //   4. Site floor
         val adminOverride = adminSlotFloorOverrides.get(slot.slotId)
           .orElse(slot.floorOverride)
         // Remember the spec-carried override (or its absence) so
@@ -1330,10 +1319,9 @@ private final class AuctioneerEntity private (
           case Some(f) => slotSpecAdminFloors.updated(slot.slotId, f)
           case None    => slotSpecAdminFloors - slot.slotId
         }
-        val rlOverride = slotFloorOverrides.get(slot.slotId)
         // Per-category effective floor: the category's learned floor (or the
         // site floor when absent) scaled by the slot's quality prior. The
-        // admin/RL override still takes precedence inside `effectiveFloor`.
+        // admin override still takes precedence inside `effectiveFloor`.
         def floorForCategory(category: String): CPM =
           SiteEntity.effectiveFloor(
             SiteEntity.AdSlotConfig(
@@ -1341,7 +1329,7 @@ private final class AuctioneerEntity private (
               width = slot.computedSize.width,
               height = slot.computedSize.height,
               prior = slot.prior,
-              floorOverride = adminOverride.orElse(rlOverride)
+              floorOverride = adminOverride
             ),
             currentCategoryFloors.getOrElse(CategoryId(category), currentFloorCpm)
           )

--- a/modules/core/src/main/scala/promovolve/auction/CategoryBidderEntity.scala
+++ b/modules/core/src/main/scala/promovolve/auction/CategoryBidderEntity.scala
@@ -105,7 +105,7 @@ object CategoryBidderEntity {
       campaignId: CampaignId,
       advertiserId: AdvertiserId,
       creatives: Set[AdvertiserEntity.Creative],
-      cpm: CPM, // RL-shaded bid (for auction ranking)
+      cpm: CPM, // quoted bid = max(maxCpm, floor) — equals maxCpm, see Candidate.cpm
       maxCpm: CPM = CPM.zero, // advertiser's max CPM (for ServeIndex)
       adProductCategory: Option[AdProductCategoryId] = None,
       landingDomain: String = "",

--- a/modules/core/src/main/scala/promovolve/package.scala
+++ b/modules/core/src/main/scala/promovolve/package.scala
@@ -38,7 +38,13 @@ final case class Candidate(
     creativeId: CreativeId,
     campaignId: CampaignId,
     advertiserId: AdvertiserId,
-    cpm: CPM, // RL-shaded bid (for auction ranking)
+    // The quoted bid: `max(maxCpm, floor)`, which equals `maxCpm` — a
+    // campaign only quotes once `maxCpm >= floor` (CampaignEntity.canBidAt),
+    // so the max never raises anyone above their own ceiling. Equal to
+    // `maxCpm` in every live path since bid shading was dropped; kept
+    // distinct only because the flagged-creative rehydrate path
+    // (SlickPendingSelectionStore) persists this and not `maxCpm`.
+    cpm: CPM,
     category: CategoryId,
     creativeHash: String = "",
     landingDomain: String = "",

--- a/modules/core/src/main/scala/promovolve/publisher/FloorSweepOptimizer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/FloorSweepOptimizer.scala
@@ -23,8 +23,13 @@ final class FloorSweepOptimizer(
 
   import FloorSweepOptimizer.*
 
-  private var _currentFloor: Double = 0.50
-  private var _minFloor: Double = 0.10
+  // Pre-configuration seeds only: SiteEntity calls setFloor/setMinFloor with
+  // the site's configured values, which the operator sets in their own
+  // currency at install. These constants are the last resort before that
+  // happens and are dollar-scale, which is the only safe guess when nothing
+  // has told us the currency.
+  private var _currentFloor: Double = DefaultFloor
+  private var _minFloor: Double = DefaultMinFloor
 
   private var phase: String = Phase.Init
   private var cursor: Int = 0
@@ -276,7 +281,7 @@ final class FloorSweepOptimizer(
       val (candMin, candMax) =
         if (effectiveMax > effectiveMin) (effectiveMin, effectiveMax)
         else if (effectiveMax > _minFloor)
-          (math.max(_minFloor, round2(effectiveMax * 0.8)), effectiveMax)
+          (math.max(_minFloor, round2(effectiveMax * 0.8, _minFloor)), effectiveMax)
         else (effectiveMin, effectiveMax)
       // Reset accumulators so this cycle's record* calls start fresh.
       // Without this, a one-time outlier would permanently bias the
@@ -284,7 +289,7 @@ final class FloorSweepOptimizer(
       maxBidObserved = 0.0
       minBidObserved = 0.0
       windowMaxBid = 0.0
-      candidates = buildCandidates(candMin, candMax, config.candidateCount)
+      candidates = buildCandidates(candMin, candMax, config.candidateCount, _minFloor)
       results = Map.empty
       cursor = 0
       ticksThisCandidate = 0
@@ -420,6 +425,15 @@ final class FloorSweepOptimizer(
 }
 
 object FloorSweepOptimizer {
+
+  /**
+   * Last-resort floor seeds, used only until SiteEntity supplies the site's
+   * configured values. Dollar-scale by necessity: nothing at this layer knows
+   * the deployment's currency, and the platform seeds real sites from the
+   * operator's setup answers.
+   */
+  val DefaultFloor: Double = 0.50
+  val DefaultMinFloor: Double = 0.10
 
   /**
    * Outcome of a single auction, reported by AuctioneerEntity to
@@ -619,11 +633,16 @@ object FloorSweepOptimizer {
    * `ticksPerCandidate` ticks on each copy — same measurement, repeated.
    * `distinct` keeps first occurrences, so ascending order is preserved.
    */
-  private[publisher] def buildCandidates(minFloor: Double, maxFloor: Double, n: Int): Vector[Double] = {
+  private[publisher] def buildCandidates(
+      minFloor: Double,
+      maxFloor: Double,
+      n: Int,
+      quantum: Double = DefaultMinFloor
+  ): Vector[Double] = {
     if (n <= 1 || maxFloor <= minFloor) Vector(minFloor)
     else {
       val step = (maxFloor - minFloor) / (n - 1).toDouble
-      (0 until n).iterator.map(i => round2(minFloor + step * i)).toVector.distinct
+      (0 until n).iterator.map(i => round2(minFloor + step * i, quantum)).toVector.distinct
     }
   }
 
@@ -665,9 +684,12 @@ object FloorSweepOptimizer {
   private[publisher] def pickBest(
       results: Map[Double, (Double, Long)],
       minImpsForArgmax: Int = 1,
-      tieTolerance: Double = 0.0
+      tieTolerance: Double = 0.0,
+      minFloor: Double = DefaultMinFloor
   ): Double = {
-    if (results.isEmpty) 0.50
+    // Empty results: the site's own minimum, not a dollar-scale literal — on
+    // a yen deployment 0.50 is no floor at all.
+    if (results.isEmpty) minFloor
     else {
       val totalRev = results.values.iterator.map(_._1).sum
       if (totalRev <= 0.0) results.keys.min
@@ -705,8 +727,22 @@ object FloorSweepOptimizer {
     }
   }
 
-  private def round2(d: Double): Double =
-    math.round(d * 100.0) / 100.0
+  /**
+   * Snap a candidate floor to a sane granularity, so a narrow sweep range
+   * doesn't emit the same floor at several cursor positions (buildCandidates
+   * dedupes on the rounded value).
+   *
+   * The step is derived from the site's minimum floor rather than fixed at one
+   * cent. A cent is only the right quantum in dollars: on a yen deployment
+   * whose floors run ¥80-¥1600, snapping to ¥0.01 dedupes nothing and stores
+   * meaningless sub-yen precision. minFloor/10 reproduces exactly the old
+   * behaviour at the dollar default (0.10 / 10 = 0.01) and scales with the
+   * market everywhere else.
+   */
+  private def round2(d: Double, siteMinFloor: Double): Double = {
+    val step = math.max(siteMinFloor / 10.0, 1e-6)
+    math.round(d / step) * step
+  }
 
   /**
    * Bid-derived floor — the monopoly shortcut. With exactly ONE bidder in a

--- a/modules/core/src/main/scala/promovolve/publisher/SiteEntity.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/SiteEntity.scala
@@ -249,11 +249,12 @@ object SiteEntity {
             else
               FloorSweepOptimizer.Config()
 
-          // In-memory ring buffer of recent floor-CPM RL decisions. Surfaces
-          // production agent behavior to the dashboard without writing to
-          // a journal. Capped so a long-lived SiteEntity doesn't grow this
-          // unboundedly. ~100 entries × 15 min/entry ≈ last 25 hours of
-          // observations. Re-created empty on actor restart.
+          // Ring buffer of recent floor-CPM sweep decisions. Surfaces the
+          // optimizer's production behavior to the dashboard without
+          // standing up a projection. Capped so a long-lived SiteEntity
+          // doesn't grow this unboundedly. ~100 entries × 15 min/entry ≈
+          // last 25 hours of observations. Rides in persisted state
+          // (State.recentFloorObservations) and is hydrated on recovery.
           val FloorObservationCap: Int = 100
           var recentFloorObservations: Vector[FloorObservation] = Vector.empty
 
@@ -869,8 +870,8 @@ object SiteEntity {
                           .thenRun { _ =>
                             // Push the full admin-overrides map to the
                             // auctioneer. Empty values mean "no admin
-                            // override" — those slots fall back to RL /
-                            // prior at scoring time.
+                            // override" — those slots fall back to the
+                            // crawler prior at scoring time.
                             val adminMap = newSlots
                               .flatMap(s => s.floorOverride.map(cpm => SlotId(s.slotId) -> cpm))
                               .toMap
@@ -1405,8 +1406,8 @@ object SiteEntity {
                         .find(_.slotId == e.slotId)
                         .fold(e)(d =>
                           // Refresh geometry + the freshly-measured prior; keep
-                          // the admin/RL floor override (prior is auto, override
-                          // is human/learned).
+                          // the admin floor override (prior is auto, override
+                          // is human).
                           e.copy(width = d.width, height = d.height,
                             prior = d.prior.orElse(e.prior))
                         )
@@ -1532,8 +1533,8 @@ object SiteEntity {
             publishSiteSuspended(state.suspended)
             publishVerifiedHost(state.verifiedHost)
             // Replay admin per-slot floor overrides to AuctioneerEntity so
-            // they survive restarts. RL overrides are transient and will
-            // be recomputed at the next observation window.
+            // they survive restarts — they are the only per-slot overrides
+            // the auctioneer takes.
             state.config.foreach { cfg =>
               val adminMap = cfg.slots
                 .flatMap(s => s.floorOverride.map(cpm => SlotId(s.slotId) -> cpm))
@@ -1684,8 +1685,8 @@ object SiteEntity {
 
   /**
    * Crawler-derived prior for a slot — feeds into the per-slot
-   * effective floor before any auction data is available. Refined
-   * over time by the floor-CPM RL agent via `floorOverride` below.
+   * effective floor before any auction data is available. Overridable
+   * by an admin via `floorOverride` below.
    *
    *   qualityScore (0..1) is a weighted combination of crawl signals
    *   (above-fold, viewability, region, text density). Drives a
@@ -1732,7 +1733,7 @@ object SiteEntity {
    * Ad slot declared on a site.
    *
    *   prior         — crawler-derived; written only by the crawler ingest path
-   *   floorOverride — RL-learned or manual; written only by RL/admin code
+   *   floorOverride — manual; written only by admin code
    *
    * Both are Option so existing journaled slots deserialize with
    * defaults and the system falls through to the site-level floor.
@@ -1856,7 +1857,7 @@ object SiteEntity {
       dayDurationSeconds: Int = 86400, // Simulated day length (default: 24h = 86400s). Set lower for testing.
       warmupMode: Boolean = false, // When true, record traffic patterns but don't serve ads. Use for learning traffic shape before campaign start.
       bidWeight: Double = 0.5, // Scoring exponent: score = CTR × CPM^α. 0.3=discovery, 0.5=balanced, 0.7=revenue.
-      floorCpm: Double = 0.50 // Current floor CPM (synced to AdServer for serve-time filtering)
+      floorCpm: Double = FloorSweepOptimizer.DefaultFloor // Current floor CPM (synced to AdServer for serve-time filtering)
   ) extends CborSerializable
 
   /**
@@ -1980,15 +1981,15 @@ object SiteEntity {
   /** Get publisher's minimum floor CPM */
   final case class GetMinFloorCpm(replyTo: ActorRef[CPM]) extends Command
 
-  /** Update publisher's minimum floor CPM (RL agent cannot go below this) */
+  /** Update publisher's minimum floor CPM (the sweep cannot go below this) */
   final case class UpdateMinFloorCpm(cpm: CPM, replyTo: ActorRef[MinFloorCpmUpdated]) extends Command
   final case class MinFloorCpmUpdated(siteId: SiteId, minFloorCpm: CPM) extends promovolve.CborSerializable
 
   /**
    * Admin escape hatch: set or clear the explicit floor for one slot.
    * `floor = None` clears the override and lets the slot fall back to
-   * the RL-learned override (if any) or the prior-scaled site floor.
-   * Admin floors take precedence over RL floors at auction time.
+   * the prior-scaled site floor. Admin floors take precedence over every
+   * learned floor at auction time.
    */
   final case class UpdateSlotFloorOverride(
       slotId: String,
@@ -2085,11 +2086,17 @@ object SiteEntity {
 
   /**
    * One snapshot of what the floor-CPM sweep optimizer did during a single
-   * 15-minute observation window. Held in an in-memory ring buffer per
+   * 15-minute observation window. Held in a bounded ring buffer per
    * SiteEntity for production observability — the dashboard reads
-   * recent entries via `GetRecentFloorObservations`. Not persisted;
-   * survives only until the actor restarts. That's deliberate — long-
-   * term retention belongs in a journal/projection, not the entity.
+   * recent entries via `GetRecentFloorObservations`.
+   *
+   * PERSISTED: rides in `State.recentFloorObservations` so the
+   * observations page keeps its rows across an api-pod restart. That
+   * makes this a serialization-schema type — renaming or retyping a
+   * field breaks recovery of existing states, so add fields with
+   * defaults (the pageClassifications / demandCategories pattern) and
+   * see FloorObservationPersistenceSpec. Long-term retention still
+   * belongs in the floor_decisions journal, not here.
    */
   final case class FloorObservation(
       ts: java.time.Instant,
@@ -2180,8 +2187,11 @@ object SiteEntity {
       adProductBlocklist: Set[AdProductCategoryId] = Set.empty,
       verificationToken: Option[VerificationToken] = None,
       verifiedHost: Option[String] = None, // normalized host, set after successful verification
-      floorCpm: CPM = CPM(0.50), // current floor CPM (managed by RL agent)
-      minFloorCpm: CPM = CPM(0.10), // publisher-set minimum floor (RL agent cannot go below this)
+      // Seeds for a site created before the platform sends its configured
+      // floors. Dollar-scale by necessity — nothing here knows the
+      // deployment currency — and overwritten at registration.
+      floorCpm: CPM = CPM(FloorSweepOptimizer.DefaultFloor), // current floor CPM (managed by the sweep optimizer)
+      minFloorCpm: CPM = CPM(FloorSweepOptimizer.DefaultMinFloor), // publisher-set minimum floor (the sweep cannot go below this)
       bidWeight: Double = 0.5, // scoring exponent: score = CTR × CPM^α (0.3=discovery, 0.5=balanced, 0.7=revenue)
       // Sweep-optimizer state, persisted so phase counters and learned
       // floor survive an actor restart.

--- a/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
+++ b/modules/core/src/main/scala/promovolve/publisher/delivery/AdServer.scala
@@ -362,6 +362,49 @@ object AdServer {
   }
 
   /**
+   * Fold a resolved batch's outcomes into the site's serve stats.
+   *
+   * Every winner increments `selected` and its hour bucket, and adds
+   * ITS CLEARING PRICE to `totalSpend` — the price the winner actually
+   * pays, never its bid. There is deliberately NO fallback from a zero
+   * clearing price to `winner.cpm`:
+   *
+   *   - Zero is a real, correct outcome. An honored dog-ear pin serves
+   *     free (the reader bookmarked the creative; no reservation runs),
+   *     and it arrives here with `winner = Some(_)` and
+   *     `clearingPrice = CPM.zero`.
+   *   - The old fallback treated that as missing data and substituted
+   *     the advertiser's full maxCpm, so every pinned impression was
+   *     booked at a price nobody paid — inflating the publisher Revenue
+   *     tile and the traffic-shape spend series in proportion to pin
+   *     rate. Billing never saw it (money runs off `reserve` at this
+   *     same clearing price), but the publisher-facing number lied.
+   *   - No auction path can produce a spurious zero to protect against:
+   *     clearing is clamped to `>= floor` (ThompsonSampling
+   *     .qualityAdjustedClearing), so a real auction win is zero only
+   *     when the floor itself is zero — in which case zero is again the
+   *     honest number.
+   *
+   * A batch with no winners at all records `noCandidates` instead.
+   *
+   * Pure — takes every input as a parameter (including the hour bucket,
+   * so tests don't depend on wall-clock time).
+   */
+  def recordBatchServeStats(
+      stats: Protocol.ServeStats,
+      outcomes: Vector[Protocol.BatchSlotOutcome],
+      hour: Int
+  ): Protocol.ServeStats =
+    if (!outcomes.exists(_.winner.isDefined)) stats.recordNoCandidates
+    else
+      outcomes.foldLeft(stats) { (acc, o) =>
+        o.winner match {
+          case Some(_) => acc.recordSelectedInBucket(hour, o.clearingPrice.toDouble / 1000.0)
+          case None    => acc
+        }
+      }
+
+  /**
    * Pick the best candidate for a slot together with its quality-
    * adjusted clearing price. Pure helper shared by the batch
    * assignment and the retry loop. Mirrors the size + floor +
@@ -2921,31 +2964,12 @@ private[delivery] class AdServer(
         log.info("BATCH SERVED: {} slots filled, {} unfilled",
           servedCount: java.lang.Integer, emptyCount: java.lang.Integer)
         replyTo ! BatchSelected(outcomes, pageCats)
-        // Increment serveStats per-winner via recordSelectedInBucket so
-        // `totalSpend` and `hourlyImpressions` update alongside `selected`.
-        // Earlier code took a shortcut (`serveStats.copy(selected += N)`)
-        // that bumped only the count and silently left totalSpend at 0 —
-        // breaks the dashboard Revenue tile and stalls traffic-shape
-        // learning since hourly buckets never populate.
-        val updatedServeStats: ServeStats = if (servedCount == 0) {
-          serveStats.recordNoCandidates
-        } else {
-          val hour = java.time.LocalTime.now(java.time.ZoneOffset.UTC).getHour
-          outcomes.foldLeft(serveStats) { (stats, o) =>
-            o.winner match {
-              case Some(_) =>
-                // Use the per-slot clearing price (what the winner actually
-                // pays). Falls back to winner.cpm when clearingPrice is
-                // zero — that case shouldn't occur in normal serve paths
-                // but keeps the counter consistent if it ever does.
-                val cpm: Double =
-                  if (o.clearingPrice.toDouble > 0) o.clearingPrice.toDouble
-                  else o.winner.map(_.cpm.toDouble).getOrElse(0.0)
-                stats.recordSelectedInBucket(hour, cpm / 1000.0)
-              case None => stats
-            }
-          }
-        }
+        val updatedServeStats: ServeStats =
+          AdServer.recordBatchServeStats(
+            serveStats,
+            outcomes,
+            java.time.LocalTime.now(java.time.ZoneOffset.UTC).getHour
+          )
         // Track creativeIds whose pin this batch honored. Best-effort signal for
         // the topic-narrow orphan-eligibility predicate: a pinned creative must
         // survive eviction when the advertiser drops a DIFFERENT topic. Pins are

--- a/modules/core/src/test/scala/promovolve/publisher/PerCategoryLearningSim.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/PerCategoryLearningSim.scala
@@ -53,21 +53,33 @@ class PerCategoryLearningSim extends AnyWordSpec with Matchers {
 
     "converge each category's optimizer to its own bidder's value ($3/$4/$5)" in {
       val opts = bidders.keys.map(c => c -> newOpt()).toMap
+      // Read the CONVERGED ARGMAX, not `currentFloorCpm`. Mid-sweep the
+      // cursor sits on whichever candidate it is probing, so sampling the
+      // live floor at an arbitrary tick asserts on a probe rather than on
+      // a decision — and which probe you land on depends on the candidate
+      // grid, which is quantized to the site's minimum floor. (This test
+      // read the live floor until 2026-07-27, when a finer/coarser grid
+      // put candidate 6 of 8 under the cursor at the final tick.) The
+      // sibling test below has always read decisions for this reason.
+      val argmax = bidders.keys.map(c => c -> scala.collection.mutable.ArrayBuffer.empty[Double]).toMap
       for (_ <- 1 to Ticks) {
         opts.foreach { case (cat, opt) =>
           feedCategory(opt, bidders(cat))
-          opt.observe()
+          opt.observe().foreach(_.completedCycle.foreach(d => argmax(cat) += d.argmaxFloor))
         }
       }
-      println(f"  per-category floors: A=$$${opts("A").currentFloorCpm}%.2f " +
-        f"B=$$${opts("B").currentFloorCpm}%.2f C=$$${opts("C").currentFloorCpm}%.2f  (optimum $$3/$$4/$$5)")
+      def converged(cat: String): Double =
+        argmax(cat).lastOption.getOrElse(opts(cat).currentFloorCpm)
+
+      println(f"  per-category floors: A=$$${converged("A")}%.2f " +
+        f"B=$$${converged("B")}%.2f C=$$${converged("C")}%.2f  (optimum $$3/$$4/$$5)")
 
       // Each category's own bounds collapse its sweep range to its own
-      // bidder's bid → the floor lands exactly there. This is the monopoly
+      // bidder's bid → the argmax lands exactly there. This is the monopoly
       // optimum the single site floor cannot reach.
-      opts("A").currentFloorCpm shouldBe 3.0 +- 0.01
-      opts("B").currentFloorCpm shouldBe 4.0 +- 0.01
-      opts("C").currentFloorCpm shouldBe 5.0 +- 0.01
+      converged("A") shouldBe 3.0 +- 0.01
+      converged("B") shouldBe 4.0 +- 0.01
+      converged("C") shouldBe 5.0 +- 0.01
     }
 
     "a single blended optimizer over the SAME traffic lands on one compromise floor" in {

--- a/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeStatsSpec.scala
+++ b/modules/core/src/test/scala/promovolve/publisher/delivery/AdServerServeStatsSpec.scala
@@ -1,0 +1,127 @@
+package promovolve.publisher.delivery
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import promovolve.{ AdvertiserId, CPM, CampaignId, CategoryId, CreativeId, SlotId }
+import promovolve.publisher.{ CDNPath, CandidateView, MimeType }
+
+/**
+ * Serve-stat accounting for a resolved batch.
+ *
+ * The invariant under test: `totalSpend` accrues the CLEARING price of
+ * each winner and nothing else. The regression this guards against is a
+ * fallback that treated `clearingPrice == 0` as missing data and
+ * substituted the winner's bid — which booked every free dog-ear pin
+ * impression at the advertiser's full maxCpm, inflating the publisher
+ * Revenue tile and the traffic-shape spend series while billing (which
+ * reads the clearing price) stayed correct.
+ */
+class AdServerServeStatsSpec extends AnyWordSpec with Matchers {
+
+  import promovolve.publisher.delivery.Protocol.*
+
+  private def candidate(cid: String, cpm: Double): CandidateView =
+    CandidateView(
+      creativeId = CreativeId(cid),
+      campaignId = CampaignId(s"camp-$cid"),
+      advertiserId = AdvertiserId(s"adv-$cid"),
+      assetUrl = CDNPath(s"/assets/$cid.png"),
+      mime = MimeType.imagePng,
+      width = 300,
+      height = 250,
+      category = CategoryId("tech"),
+      cpm = CPM(cpm),
+      classifiedAtMs = 0L
+    )
+
+  private def won(slot: String, bid: Double, clearing: Double): BatchSlotOutcome =
+    BatchSlotOutcome(
+      slotId = SlotId(slot),
+      winner = Some(candidate(slot, bid)),
+      clearingPrice = CPM(clearing)
+    )
+
+  /** An honored dog-ear pin: a real winner that serves free. */
+  private def pinned(slot: String, bid: Double): BatchSlotOutcome =
+    BatchSlotOutcome(
+      slotId = SlotId(slot),
+      winner = Some(candidate(slot, bid)),
+      clearingPrice = CPM.zero,
+      dogear = Some(DogearOutcome(honored = true))
+    )
+
+  private def empty(slot: String): BatchSlotOutcome =
+    BatchSlotOutcome(slotId = SlotId(slot), winner = None)
+
+  private val hour = 9
+
+  "AdServer.recordBatchServeStats" should {
+
+    "accrue the clearing price, not the bid" in {
+      val stats =
+        AdServer.recordBatchServeStats(ServeStats("site-1"), Vector(won("a", bid = 5.0, clearing = 2.0)), hour)
+
+      stats.selected shouldBe 1
+      stats.totalSpend shouldBe 0.002 +- 1e-9 // 2.00 CPM = $0.002 per impression
+      stats.hourlyImpressions(hour) shouldBe 1
+    }
+
+    "book an honored pin at ZERO, not at the winner's bid" in {
+      val stats = AdServer.recordBatchServeStats(ServeStats("site-1"), Vector(pinned("a", bid = 5.0)), hour)
+
+      // The impression is real and counted...
+      stats.selected shouldBe 1
+      stats.hourlyImpressions(hour) shouldBe 1
+      // ...but it was free. The regression booked $0.005 here.
+      stats.totalSpend shouldBe 0.0 +- 1e-9
+    }
+
+    "keep a paid winner's spend intact when a free pin shares the batch" in {
+      val stats = AdServer.recordBatchServeStats(
+        ServeStats("site-1"),
+        Vector(won("a", bid = 5.0, clearing = 2.0), pinned("b", bid = 9.0)),
+        hour
+      )
+
+      stats.selected shouldBe 2
+      stats.hourlyImpressions(hour) shouldBe 2
+      stats.totalSpend shouldBe 0.002 +- 1e-9
+    }
+
+    "ignore unfilled slots but still count the filled ones" in {
+      val stats = AdServer.recordBatchServeStats(
+        ServeStats("site-1"),
+        Vector(won("a", bid = 5.0, clearing = 2.0), empty("b")),
+        hour
+      )
+
+      stats.selected shouldBe 1
+      stats.totalSpend shouldBe 0.002 +- 1e-9
+    }
+
+    "record noCandidates when the batch filled nothing" in {
+      val stats = AdServer.recordBatchServeStats(ServeStats("site-1"), Vector(empty("a"), empty("b")), hour)
+
+      stats.noCandidates shouldBe 1
+      stats.selected shouldBe 0
+      stats.totalSpend shouldBe 0.0 +- 1e-9
+    }
+
+    "treat an all-pins batch as served, not as noCandidates" in {
+      val stats = AdServer.recordBatchServeStats(ServeStats("site-1"), Vector(pinned("a", 5.0), pinned("b", 3.0)), hour)
+
+      stats.noCandidates shouldBe 0
+      stats.selected shouldBe 2
+      stats.totalSpend shouldBe 0.0 +- 1e-9
+    }
+
+    "accumulate onto existing stats rather than replacing them" in {
+      val seed = AdServer.recordBatchServeStats(ServeStats("site-1"), Vector(won("a", 5.0, 2.0)), hour)
+      val stats = AdServer.recordBatchServeStats(seed, Vector(won("b", 5.0, 3.0)), hour)
+
+      stats.selected shouldBe 2
+      stats.totalSpend shouldBe 0.005 +- 1e-9
+      stats.hourlyImpressions(hour) shouldBe 2
+    }
+  }
+}


### PR DESCRIPTION
The RL floor agent and campaign-side bid shading were removed long ago, but their scaffolding and vocabulary survived and actively misled: a reader tracing pricing hits "RL-shaded bid (for auction ranking)" on Candidate.cpm, which is neither shaded nor distinct from maxCpm.

DEAD CODE
- Delete AuctioneerEntity.UpdateSlotFloors, its handler, the slotFloorOverrides var and the rlOverride local. Zero producers: the sweep optimizer emits site- and category-level floors only, so the map was permanently empty and `adminOverride.orElse(rlOverride)` was just `adminOverride`. Tombstoned in the style of the BidCpmChanged removal. Per-slot floor priority drops from 5 entries to 4.

SERVE-STAT ACCOUNTING (real bug)
- An honored dog-ear pin serves free and reaches the ServeStats fold with winner = Some(_) and clearingPrice = CPM.zero. The fold treated zero as missing data and substituted winner.cpm, booking every pinned impression at the advertiser's full maxCpm. That inflated the publisher Revenue tile and the traffic-shape spend series in proportion to pin rate. Billing was never affected — money runs off `reserve` at the clearing price. Removed the fallback outright rather than special-casing pins: no input existed for which it improved the number.
- Extracted the fold as the pure AdServer.recordBatchServeStats (hour passed in, so tests don't depend on wall-clock), matching the batchAssign / pickBestForSlot idiom, and covered it with AdServerServeStatsSpec. Verified the spec catches the regression: reinstating the fallback fails 3 of 7 with "0.005 was not 0.0".

TEST CORRECTNESS
- PerCategoryLearningSim asserted on currentFloorCpm, which mid-sweep is whichever candidate the cursor is probing, not a decision. It read candidate 6 of 8 at the final tick. Now reads the converged argmax from completed-cycle decisions, as its sibling test always has. The sweep itself was correct throughout (argmax=3.0 every cycle); the original ±0.01 tolerance holds unchanged, landing exactly on $3/$4/$5.

DOCS / COMMENTS
- Candidate.cpm and CampaignBid.cpm now state what the field is: max(maxCpm, floor), which equals maxCpm because a campaign only quotes once maxCpm >= floor. Records why the two fields still differ (the flagged-creative rehydrate path persists cpm, not maxCpm).
- FloorObservation's docstring claimed "Not persisted" while riding in persisted State — anyone trusting it would rename a field and break site recovery. Now flags it as a serialization-schema type. Same false claim removed from the floor-observations API description.
- API summaries: "floor-RL agent" -> "floor-sweep optimizer".
- Kept the accurate history: the why-not-RL rationale, the BidCpmChanged tombstone, and the config note explaining a name is NOT RL-related. epsilon/trainingLoss keep their RL-era JSON keys (persisted + public contract); documented rather than renamed.

Scala only. The two equivalent comment fixes in platform/internal/handler are deliberately left out: those files carry a concurrent agent's in-flight work importing an as-yet-untracked internal/currency package, so including them broke `go build`. They can ride along with that work instead.

Verified in a CLEAN WORKTREE at this exact commit (not the warm local cache, which masked a scalafmt violation in the new spec): compile + Test/compile clean, scalafmtCheckAll passes, core/test 580 passed with the 2 pre-existing baseline failures (Anthropic integration needs a live key, BloomFilter large-scale) and the pre-existing TaxonomyRanker abort.

NOTE: SiteEntity, ApiModels, ApiJsonFormats and FloorSweepOptimizer also carry in-flight base-currency work from a concurrent agent, swept in here because it shares lines with these edits (DefaultFloor / DefaultMinFloor and the CreateSiteRequest.floorCpm jsonFormat7 bump are compile dependencies). To be separated later.