### PR TITLE
Align documented Java requirements with JDK 21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ See the [README](README.md#repository-layout) for the map. The two build targets
 
 ## Prerequisites
 
-- **JDK 17+ and sbt** (Scala 3.7)
+- **JDK 21 and sbt** (Scala 3.7)
 - **Go 1.26+**
 - **Node.js** (to build the Tailwind CSS and the JS ad bundles)
 - **Docker** (local Postgres/TimescaleDB)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ scripts/run-dev.sh --fresh             # core API on :8080
 scripts/run-dashboard.sh               # dashboard on :9091
 ```
 
-You'll need JDK + sbt, Go, Node.js, Docker, a Cloudflare R2 bucket, and
+You'll need JDK 21 and sbt, Go, Node.js, Docker, a Cloudflare R2 bucket, and
 one LLM API key (Gemini, OpenAI, or Anthropic) — the core refuses to boot
 without R2 and an LLM provider. Details in the
 [self-hosting guide](docs/guides/self-hosting.md).

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -56,8 +56,8 @@ The app runs fully without them; both are single, well-marked seams.
 - An LLM API key. The core API **hard-fails at boot** without one of
   `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` (precedence
   in that order). Classification and creative generation run through it.
-- Node.js (to build/publish the JS bundles) and JDK/sbt + Go if building
-  images yourself.
+- Node.js (to build/publish the JS bundles), JDK 21 with sbt, and Go if
+  building images yourself.
 
 ## Step 1 — R2 bucket and CDN origin
 


### PR DESCRIPTION
## Summary

- Update contributor prerequisites from JDK 17+ to JDK 21
- State JDK 21 explicitly in the root README and self-hosting guide
- Align documentation with CI and the Java 21 container images

Node.js version standardization is tracked separately in #16.

## Validation

- Confirmed CI uses Temurin 21
- Confirmed `Dockerfile` and `Dockerfile.api` use Java 21 images
- Confirmed the updated documentation no longer presents JDK 17 as the development baseline
- Passed `git diff --check`

Closes #14
