### PR TITLE
chore: Configure Dependabot and guarded auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,179 @@
+version: 2
+
+# Keep Dependabot's default `dependencies` label.
+updates:
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/platform/banner-bootstrap"
+      - "/platform/banner-component"
+      - "/platform/creative-designer"
+      - "/platform/dashboard-tests"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "gomod"
+    directory: "/platform"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/scripts/rl-test"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/platform"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "docker-compose"
+    directories:
+      - "/"
+      - "/integrations/wordpress"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    groups:
+      minor-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor"]
+      patch-updates:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npx vitest run
+      - run: npm run build
       # Animation viewability contract: collapsed-banner item motion must
       # HOLD until the banner is ≥50% visible (and the atomic reveal has
       # lifted), then play; reduced-motion poses instantly at render. The
@@ -135,6 +136,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run test
+      - run: npm run build
 
   datepicker:
     name: Dashboard date-picker (browser)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,72 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.repository == 'promovolve/promovolve'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve eligible Dependabot PR
+        if: >-
+          (
+            (
+              (steps.dependabot-metadata.outputs.package-ecosystem == 'npm' ||
+               steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn') &&
+              contains(
+                fromJSON('["/platform/banner-bootstrap","/platform/banner-component","/platform/creative-designer","/platform/dashboard-tests"]'),
+                steps.dependabot-metadata.outputs.directory
+              )
+            ) ||
+            (
+              steps.dependabot-metadata.outputs.package-ecosystem == 'gomod' &&
+              steps.dependabot-metadata.outputs.directory == '/platform'
+            )
+          ) &&
+          (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor') &&
+          steps.dependabot-metadata.outputs.maintainer-changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge for eligible updates
+        if: >-
+          (
+            (
+              (steps.dependabot-metadata.outputs.package-ecosystem == 'npm' ||
+               steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn') &&
+              contains(
+                fromJSON('["/platform/banner-bootstrap","/platform/banner-component","/platform/creative-designer","/platform/dashboard-tests"]'),
+                steps.dependabot-metadata.outputs.directory
+              )
+            ) ||
+            (
+              steps.dependabot-metadata.outputs.package-ecosystem == 'gomod' &&
+              steps.dependabot-metadata.outputs.directory == '/platform'
+            )
+          ) &&
+          (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor') &&
+          steps.dependabot-metadata.outputs.maintainer-changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

Implement #12 by configuring Dependabot for all supported ecosystems and adding guarded auto-merge for eligible npm and Go updates.

Issue #33 has been resolved separately and is no longer a blocker for this PR.

## Changes

- Add daily Dependabot updates at 02:00 in `Asia/Tokyo`
- Apply a seven-day cooldown and the `dependencies` label
- Limit each ecosystem to one open version-update PR during the initial rollout
- Group patch and minor updates separately
- Configure all supported ecosystems using explicit manifest directories
- Add a SHA-pinned auto-merge workflow
- Restrict auto-merge to Dependabot PRs targeting `main`
- Restrict auto-merge to SemVer patch/minor updates from:
  - npm: `/platform/banner-bootstrap`
  - npm: `/platform/banner-component`
  - npm: `/platform/creative-designer`
  - npm: `/platform/dashboard-tests`
  - Go: `/platform`
- Run production builds in the required Creative Designer and Bootstrap CI jobs
- Keep every other ecosystem, directory, major update, and non-SemVer update on manual review

## Safety

The workflow:

- Runs only for Dependabot PRs targeting `main` in `promovolve/promovolve`
- Verifies Dependabot metadata and the explicit ecosystem/directory allowlist
- Rejects updates with upstream package maintainer changes
- Uses a SHA-pinned action
- Does not check out or execute PR-controlled code
- Uses `gh pr review --approve` and `gh pr merge --auto --squash`
- Relies on the existing Ruleset and required checks before merging

## Required repository setting

Completed before merge: `Bootstrap (publisher ad tag)` is required by the `main` Ruleset because `/platform/banner-bootstrap` is auto-merge eligible. The required Dependabot features, Actions approval permission, repository auto-merge setting, pull-request requirement, and no-bypass Ruleset are also enabled.

## Verification

After merge, verify one eligible npm or Go patch/minor update and one ineligible update to confirm the allowlist, approval behavior, required checks, and auto-merge behavior. Keep #12 open until this rollout verification is complete.
