### PR TITLE
ci: land deploy pin-backs through an auto-merging pull request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,12 @@
 # kustomize secretGenerator needs k8s/*.env, which stay on the laptop and
 # out of GitHub). Infra/config changes deploy via `k8s-gke/setup.sh
 # --deploy-only` from a machine that has them; CI only moves images.
-# Consequence: the digests pinned in k8s/kustomization.yaml are the DEV
-# (Docker Desktop) cluster's source of truth and a manual setup.sh deploy
-# rolls GKE back to them — after CI deploys, refresh the pins before any
-# manual deploy.
+# Consequence: the digests pinned in k8s/kustomization.yaml are what a
+# manual setup.sh deploy renders, so after every rollout the pin-images /
+# publish-banner jobs write the live digests and banner URL back — through
+# a pull request (branch `ci/pins`, auto-merged once CI is green), because
+# the `main` Ruleset forbids direct pushes. Until that PR lands the pins
+# lag the cluster; setup.sh refuses to apply while it is open.
 #
 # The `:dev` tag stays laptop-owned (this workflow never writes it).
 #
@@ -251,70 +253,49 @@ jobs:
             kubectl -n promovolve rollout status deployment/promovolve-platform --timeout=300s
           fi
 
-  # Write the digests we just rolled back into k8s/kustomization.yaml, so the
-  # repo always describes what is actually deployed.
-  #
-  # Without this the pins were hand-maintained and permanently behind main,
-  # which is not cosmetic: a manual overlay apply deploys the PINS and rolls
-  # the app backwards (2026-07-12 reverted four shipped fixes; 2026-07-27
-  # gke-factory-reset.sh reverted api+singleton to a four-day-old build and
-  # every /v1/internal/* route vanished with it). And on a CLEAN install there
-  # is nothing running to preserve, so the pins are simply what deploys —
-  # which is the open-source path (k8s-gke/setup.sh --build-images), so a
-  # stale pin means a stranger's first install is born broken.
-  #
-  # No CI loop: this commit touches only k8s/kustomization.yaml, which matches
-  # neither the `api` nor the `platform` paths-filter, so the Deploy it
-  # triggers skips both builds and deploys nothing. `[skip ci]` keeps it from
-  # burning a run at all.
+  # Write the deployed digests back to k8s/kustomization.yaml so the pins
+  # describe what is running (see scripts/pin-image-digest.sh for the two
+  # rollbacks that motivated it). Landed via a pull request on the shared
+  # `ci/pins` branch — never a direct push: the `main` Ruleset requires a
+  # PR + green checks, and a direct push failed with GH013 after an
+  # otherwise successful rollout (2026-08-30 ×3, GH #33). The PR auto-merges
+  # (squash) once CI passes; its title carries `[skip ci]` so the resulting
+  # commit does not burn a Deploy run (it matches no paths-filter anyway).
   pin-images:
     name: Pin deployed digests back to the repo
     needs: [build-api, build-platform, deploy]
     if: "!cancelled() && needs.deploy.result == 'success'"
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # the only job here that writes to the repo
+      contents: write        # push the ci/pins branch
+      pull-requests: write   # open the PR + enable auto-merge
+      actions: write         # dispatch CI on the branch (GITHUB_TOKEN pushes never trigger it)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
-          # Default token can push; the checkout must keep credentials for it.
-          persist-credentials: true
+          fetch-depth: 0             # merge-base / merge need real history
+          persist-credentials: true  # the pin-back script pushes
 
-      - name: Update pins
+      - name: Pin digests via pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          API_OK: ${{ needs.build-api.result == 'success' }}
+          API_DIGEST: ${{ needs.build-api.outputs.digest }}
+          PLATFORM_OK: ${{ needs.build-platform.result == 'success' }}
+          PLATFORM_DIGEST: ${{ needs.build-platform.outputs.digest }}
         run: |
           set -euo pipefail
-          if [ "${{ needs.build-api.result }}" = "success" ]; then
-            scripts/pin-image-digest.sh api \
-              "${{ needs.build-api.outputs.digest }}" \
-              "${GITHUB_SHA:0:7}" "${GITHUB_RUN_ID}"
-          fi
-          if [ "${{ needs.build-platform.result }}" = "success" ]; then
-            scripts/pin-image-digest.sh platform \
-              "${{ needs.build-platform.outputs.digest }}" \
-              "${GITHUB_SHA:0:7}" "${GITHUB_RUN_ID}"
-          fi
-
-      - name: Commit if anything changed
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- k8s/kustomization.yaml; then
-            echo "pins already current — nothing to commit"; exit 0
-          fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add k8s/kustomization.yaml
-          git commit -m "ci: pin deployed image digests [skip ci]" \
-                     -m "Deployed by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}."
-          # Someone may have pushed while the rollout ran; rebase and retry
-          # once rather than failing a deploy that already succeeded.
-          for i in 1 2 3; do
-            if git push origin HEAD:main; then exit 0; fi
-            echo "push rejected (attempt $i) — rebasing on main"
-            git pull --rebase origin main
-          done
-          echo "could not push updated pins after 3 attempts" >&2
-          exit 1
+          # The pin command is re-run on every push retry, so it must be a
+          # single idempotent step: both components in one go.
+          scripts/pin-back-pr.sh \
+            "ci: pin deployed image digests [skip ci]" \
+            "Deployed by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}." \
+            bash -c '
+              set -euo pipefail
+              [ "$API_OK" = "true" ] && scripts/pin-image-digest.sh api "$API_DIGEST" "${GITHUB_SHA:0:7}" "$GITHUB_RUN_ID"
+              [ "$PLATFORM_OK" = "true" ] && scripts/pin-image-digest.sh platform "$PLATFORM_DIGEST" "${GITHUB_SHA:0:7}" "$GITHUB_RUN_ID"
+              true'
 
   # Publish the delivered banner runtime to R2 and point the cluster at the
   # new immutable URL. This is the piece CI historically did NOT do — the
@@ -345,13 +326,15 @@ jobs:
       && needs.deploy.result != 'failure'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # pins the published URL back. Job-level permissions
-      id-token: write   # REPLACE the top-level pair, so WIF's id-token must
-                        # be respelled here or the gcloud auth step breaks.
+      contents: write        # pins the published URL back (ci/pins branch).
+      pull-requests: write   # Job-level permissions REPLACE the top-level
+      actions: write         # pair, so WIF's id-token must be respelled
+      id-token: write        # here or the gcloud auth step breaks.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: main
+          fetch-depth: 0              # pin-back merges main into ci/pins
           persist-credentials: true   # the pin-back step pushes
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -408,24 +391,18 @@ jobs:
       # k8s-gke/setup.sh drops that literal before applying, which is only
       # correct while this line is true.
       - name: Pin the published URL back to the repo
+        env:
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.publish.outputs.url }}
         run: |
           set -euo pipefail
-          scripts/pin-banner-url.sh "${{ steps.publish.outputs.url }}"
-          if git diff --quiet -- k8s/kustomization.yaml; then
-            echo "banner url already current — nothing to commit"; exit 0
-          fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add k8s/kustomization.yaml
-          git commit -m "ci: pin published banner bundle url [skip ci]" \
-                     -m "Published by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}."
-          for i in 1 2 3; do
-            if git push origin HEAD:main; then exit 0; fi
-            echo "push rejected (attempt $i) — rebasing on main"
-            git pull --rebase origin main
-          done
-          echo "could not push the updated banner url after 3 attempts" >&2
-          exit 1
+          # Same PR path as pin-images (shared `ci/pins` branch — the two
+          # jobs run concurrently and the script re-applies on a push race,
+          # so neither pin can overwrite the other).
+          scripts/pin-back-pr.sh \
+            "ci: pin published banner bundle url [skip ci]" \
+            "Published by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}." \
+            scripts/pin-banner-url.sh "$URL"
 
   # The publisher ad tag. Bootstrap releases used to be MANUAL (npm run
   # release from a laptop with scripts/.env) — a merged tag fix that nobody

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ Two build traps worth knowing (both self-inflicted footguns if skipped):
 
 ## Commits & pull requests
 
+- **Everything lands on `main` through a pull request** — a repository
+  Ruleset requires one, with the CI checks green, and squash-merges it.
+  Maintainers included; CI's own digest pin-back goes through a PR too
+  (`scripts/pin-back-pr.sh`). Merging to `main` is what deploys.
 - **Conventional-commit style** subject lines (`feat:`, `fix:`, `chore:`,
   `docs:`, `refactor:`), matching the existing history.
 - Keep PRs **focused** — one logical change per PR is much easier to review.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ closed ad network can offer. For the guided version, read
 | `platform/` | The dashboard: a Go web app (server-rendered templates, passkey auth) plus the banner web component and the publisher loader script |
 | `docs/` | [Documentation index](docs/README.md) — guides, architecture, design docs |
 | `k8s/` | Base Kubernetes manifests (Kustomize) |
-| `k8s-gke/` | The public GKE deployment: ARM spot cluster, GKE Ingress + managed certs, CI-deployed on push to `main` (`.github/workflows/deploy.yml`) |
+| `k8s-gke/` | The public GKE deployment: ARM spot cluster, GKE Ingress + managed certs, CI-deployed on merge to `main` (`.github/workflows/deploy.yml`) |
 | `docker/` | Database schema (`init-db.sql`) and container bits |
 | `scripts/` | Dev runners, asset publish scripts, test harnesses |
 

--- a/k8s-gke/README.md
+++ b/k8s-gke/README.md
@@ -66,7 +66,7 @@ permanently.
 
 ## Redeploys (maintainer / staging)
 
-CI builds and rolls images by digest on every push to `main`; that is the
+CI builds and rolls images by digest on every merge to `main`; that is the
 normal path and needs nothing here. For an infra/config-only change:
 
 ```sh
@@ -77,9 +77,14 @@ which preserves the running CI-deployed images across the apply. To
 deliberately deploy the digests pinned in `k8s/kustomization.yaml` instead,
 add `--pin-images`.
 
-> **The pins are written back by CI** (`deploy.yml`'s `pin-images` job, via
-> `scripts/pin-image-digest.sh`), so `k8s/kustomization.yaml` describes what
-> is actually deployed. Do not hand-edit them.
+> **The pins are written back by CI** (`deploy.yml`'s `pin-images` and
+> `publish-banner` jobs, via `scripts/pin-back-pr.sh`), so
+> `k8s/kustomization.yaml` describes what is actually deployed. Do not
+> hand-edit them. They land **through a pull request** on the `ci/pins`
+> branch — `main` requires a PR and green checks, so CI cannot push to it —
+> which auto-merges once CI passes. Until it merges the pins lag the
+> cluster, and `setup.sh` refuses to apply while that PR is open
+> (`--allow-open-pins` overrides).
 >
 > They used to be hand-maintained, and drifted permanently behind `main`.
 > That is why `--deploy-only` preserves the running images across an apply:
@@ -140,12 +145,22 @@ script always passes `--context` explicitly, so it can't land in
 
 ## CI deploys (.github/workflows/deploy.yml)
 
-Push to `main` → the changed image(s) build natively on arm64 runners →
+Merge to `main` → the changed image(s) build natively on arm64 runners →
 Docker Hub (`main-<sha>` tags; `:dev` stays laptop-owned) → `kubectl set
-image` by digest on the GKE workloads. CI never renders the kustomize
-overlay (secrets stay off GitHub), so **a manual `setup.sh --deploy-only`
-rolls GKE back to the digests pinned in k8s/kustomization.yaml** — refresh
-the pins after CI deploys if you intend to deploy manually.
+image` by digest on the GKE workloads → the rolled digests (and, after a
+banner publish, the bundle URL) are written back to `k8s/kustomization.yaml`
+via an auto-merging pull request. CI never renders the kustomize overlay
+(secrets stay off GitHub), so **a manual `setup.sh --deploy-only` renders
+the pins** — which is why they are kept true, and why the script refuses to
+run while a pin-back PR is still open.
+
+`main` is protected by a Ruleset (pull request + the five CI checks, squash
+merges only). Nothing pushes to it directly — not contributors, not CI. The
+pin-back PR needs two repository settings that are already on: *Allow
+GitHub Actions to create and approve pull requests* and *Allow auto-merge*.
+It uses the default `GITHUB_TOKEN`, whose pushes never trigger workflows,
+so the pin job dispatches `ci.yml` on the branch itself to produce the
+required checks.
 
 Auth: GCP via Workload Identity Federation (pool `github`, provider
 `github-oidc`, SA `github-deployer@promovolve.iam.gserviceaccount.com`,

--- a/k8s-gke/setup.sh
+++ b/k8s-gke/setup.sh
@@ -92,6 +92,10 @@ while [ $# -gt 0 ]; do
     --apply-only)   APPLY_ONLY=1; DEPLOY_ONLY=1; shift ;;
     --pin-images)   PIN_IMAGES=1; shift ;;
     --build-images) BUILD_IMAGES=1; shift ;;
+    # Apply even though a CI pin-back pull request (branch ci/pins) is still
+    # open, i.e. the repo's pins are known to lag the cluster. See the guard
+    # below for what that costs.
+    --allow-open-pins) ALLOW_OPEN_PINS=1; shift ;;
     -h|--help) sed -n '2,52p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1 (try --help)" >&2; exit 2 ;;
   esac
@@ -289,6 +293,19 @@ fi
 # override was pinning. Harmless when there is no override to remove.
 if kc get deployment promovolve-platform >/dev/null 2>&1; then
   kc set env deployment/promovolve-platform BANNER_SCRIPT_URL- >/dev/null 2>&1 || true
+fi
+
+# CI writes the live digests and banner URL back to k8s/kustomization.yaml
+# THROUGH A PULL REQUEST (deploy.yml -> scripts/pin-back-pr.sh, branch
+# ci/pins, auto-merged once CI is green) because the main Ruleset forbids
+# direct pushes. While that PR is open the pins here are stale: the image
+# restore above covers the digests, but the api-config render carries the
+# OLD BANNER_SCRIPT_URL and the override-drop above makes it authoritative,
+# so an apply now would point visitors back at the previous bundle. Refuse
+# unless told otherwise; the check is advisory-only where gh is absent.
+if [ "${ALLOW_OPEN_PINS:-0}" -ne 1 ] && command -v gh >/dev/null 2>&1; then
+  open_pins=$(gh pr list --head ci/pins --state open --json url --jq '.[0].url // empty' 2>/dev/null || true)
+  [ -z "$open_pins" ] || die "a CI pin-back PR is still open ($open_pins) — the repo's pins lag the cluster. Merge it (or wait for auto-merge), then re-run; --allow-open-pins overrides."
 fi
 
 echo "==> applying manifests (kustomize overlay k8s-gke, registry ${REGISTRY})"

--- a/scripts/pin-back-pr.sh
+++ b/scripts/pin-back-pr.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Land a CI-generated pin update on `main` THROUGH A PULL REQUEST.
+#
+# WHY THIS EXISTS: deploy.yml's pin-images and publish-banner jobs used to
+# commit k8s/kustomization.yaml and `git push origin HEAD:main`. The `main`
+# Ruleset requires a pull request and green status checks, so a rollout
+# would SUCCEED and then the pin-back step failed with GH013 (2026-08-30,
+# three deploys in a row; GH issue #33). This script keeps the Ruleset
+# intact — no bypass for github-actions[bot] — and still gets the pins
+# onto main without a human in the loop:
+#
+#   1. check out the shared pin branch (ci/pins), created from main when
+#      absent; merge main into it if it has fallen behind
+#   2. run the caller's pin command (scripts/pin-image-digest.sh or
+#      scripts/pin-banner-url.sh) against the working tree
+#   3. commit k8s/kustomization.yaml and push the branch — on rejection
+#      re-fetch and re-run the pin command rather than rebasing a commit,
+#      so a concurrent pin from the OTHER job is never overwritten
+#   4. open the PR if none is open for the branch, dispatch the CI
+#      workflow on it (pushes made with GITHUB_TOKEN do not trigger
+#      `pull_request` runs, and the Ruleset needs those five checks), and
+#      enable auto-merge (squash) so it lands as soon as CI is green
+#
+# ONE branch, ONE PR: digest and banner pins from the same deploy share it,
+# a rerun finds it already open, and delete-branch-on-merge retires it so
+# the next deploy starts fresh from main. The PR title carries `[skip ci]`
+# so the squash commit it produces does not trigger a Deploy (the change
+# matches no paths-filter anyway, but this saves the run entirely).
+#
+#   scripts/pin-back-pr.sh "<commit subject>" "<commit body>" <pin-command...>
+#
+# Requires: gh (authenticated), a checkout with push credentials, and the
+# calling job to hold `contents: write`, `pull-requests: write`, and
+# `actions: write`. Repository settings: "Allow GitHub Actions to create
+# and approve pull requests" and "Allow auto-merge" must be on.
+#
+# Idempotent: with nothing to pin it exits 0 without a commit, but still
+# makes sure an open PR (from an earlier job) has CI + auto-merge armed.
+set -euo pipefail
+
+SUBJECT="${1:?usage: pin-back-pr.sh <commit subject> <commit body> <pin-command...>}"
+BODY="${2:?missing commit body}"
+shift 2
+[ $# -ge 1 ] || { echo "missing pin command" >&2; exit 2; }
+
+BRANCH="${PIN_BRANCH:-ci/pins}"
+BASE="${PIN_BASE:-main}"
+FILE="k8s/kustomization.yaml"
+PR_TITLE="ci: pin deployed digests / banner url [skip ci]"
+
+cd "$(git rev-parse --show-toplevel)"
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+# --- 1–3. pin, commit, push (retry on a concurrent push) -----------------------
+pushed=0; committed=0
+for attempt in 1 2 3 4 5; do
+  git fetch -q origin "$BASE"
+  if git fetch -q origin "$BRANCH" 2>/dev/null; then
+    git checkout -q -B "$BRANCH" "origin/$BRANCH"
+    # Keep the pin branch on top of main so its CI run reflects current
+    # code. Squash-merge makes the merge commit vanish on landing. A conflict
+    # means someone hand-edited a CI-owned line on main; the file says not
+    # to, so fail loudly rather than guess.
+    if ! git merge-base --is-ancestor "origin/$BASE" HEAD; then
+      git merge -q --no-edit "origin/$BASE" \
+        || { git merge --abort; echo "merge of $BASE into $BRANCH conflicts — resolve by hand" >&2; exit 1; }
+    fi
+  else
+    git checkout -q -B "$BRANCH" "origin/$BASE"
+  fi
+
+  "$@"
+
+  if git diff --quiet -- "$FILE"; then
+    echo "pins already current on $BRANCH — nothing to commit"
+    pushed=1; break
+  fi
+  git add "$FILE"
+  git commit -q -m "$SUBJECT" -m "$BODY"
+  if git push -q origin "HEAD:refs/heads/$BRANCH"; then
+    pushed=1; committed=1; break
+  fi
+  # Someone (the sibling pin job, most likely) pushed first. Drop our commit
+  # and re-apply the pin on top of theirs — re-running the pin command is
+  # the merge strategy, so neither change can be lost.
+  echo "push rejected (attempt $attempt) — re-applying on the latest $BRANCH"
+  git reset -q --hard "HEAD~1"
+done
+[ "$pushed" -eq 1 ] || { echo "could not push $BRANCH after 5 attempts" >&2; exit 1; }
+
+# If the branch carries nothing beyond main there is no PR to open — this is
+# the "already pinned, rerun" case with no earlier job having pushed either.
+if git merge-base --is-ancestor HEAD "origin/$BASE"; then
+  echo "$BRANCH has no changes against $BASE — no pull request needed"
+  exit 0
+fi
+
+# --- 4. PR + CI + auto-merge ---------------------------------------------------
+pr=$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json number --jq '.[0].number // empty')
+if [ -z "$pr" ]; then
+  pr=$(gh pr create --base "$BASE" --head "$BRANCH" \
+        --title "$PR_TITLE" \
+        --body "$(printf '%s\n\n%s\n\n%s' \
+          "Generated by deploy.yml — writes what the cluster is actually running back into \`k8s/kustomization.yaml\` so a manual \`k8s-gke/setup.sh --deploy-only\` cannot roll it backwards." \
+          "Auto-merges once CI is green. Each commit names the Deploy run that produced it." \
+          "Do not hand-edit; if it conflicts, close it and the next deploy opens a fresh one.")")
+  pr="${pr##*/}"
+  echo "opened pull request #$pr"
+else
+  echo "pull request #$pr already open for $BRANCH"
+fi
+
+# Required checks come from the CI workflow, which a GITHUB_TOKEN push never
+# triggers; workflow_dispatch is the sanctioned exception. Its concurrency
+# group cancels a run an earlier pin job started on a stale head. A run that
+# pushed nothing leaves the earlier dispatch (on the same head) alone.
+if [ "$committed" -eq 1 ]; then
+  gh workflow run ci.yml --ref "$BRANCH"
+  echo "dispatched CI on $BRANCH"
+fi
+
+# Squash is the only merge method the Ruleset allows. Auto-merge waits for
+# the required checks; a rerun that finds it already enabled is a no-op.
+gh pr merge "$pr" --auto --squash \
+  || echo "auto-merge could not be enabled on #$pr — merge it by hand once CI is green" >&2
+echo "pull request: $(gh pr view "$pr" --json url --jq .url)"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -90,8 +90,8 @@ backend block if a team shares this). Never point it at the live
    Terraform-created resources and skip.)
 4. **Wait for the managed cert** (15–60 min after DNS resolves), then
    register the first account at `https://<dashboard-host>/setup`.
-5. **Push to main** — CI builds arm64 images and rolls the cluster by
-   digest.
+5. **Merge to main** (via a pull request — `main` is protected) — CI
+   builds arm64 images and rolls the cluster by digest.
 
 ## Notes
 


### PR DESCRIPTION
Closes #33.

## What
- `scripts/pin-back-pr.sh`: shared pin-back that lands `k8s/kustomization.yaml` changes on `main` through a PR on branch `ci/pins` (opens it once, dispatches `ci.yml` on the branch for the required checks, enables squash auto-merge). Concurrent digest + banner pins share the branch; a rejected push re-applies the pin on the winner's commit instead of rebasing, so neither is lost.
- `deploy.yml`: `pin-images` and `publish-banner` call it instead of `git push origin HEAD:main`. Job permissions: `contents`, `pull-requests`, `actions` write. No Ruleset bypass.
- `k8s-gke/setup.sh`: refuses to apply while a `ci/pins` PR is open (the render would make the previous banner URL authoritative); `--allow-open-pins` overrides.
- Docs: main is PR-only, pin-back mechanics, required repo settings (Actions may create PRs, auto-merge) — both already on.

## Why
Main's Ruleset requires a PR + checks. Direct pin-back pushes failed with GH013 after successful rollouts (2026-08-30 ×3), and the Ruleset was disabled as a stopgap. This lets it be re-enabled.

## Verified
Local bare-origin harness with a stubbed `gh`: fresh branch, second job on an existing branch, idempotent rerun, forced push race, main moving ahead. Full loop (real PR, dispatched CI, auto-merge) gets exercised by the first deploy after this merges.

https://claude.ai/code/session_016UVYxxNiRjCufNPjzUzDgf