### PR TITLE
ci: push the pin branch with a deploy key so its checks count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # ci/pins is the CI-generated pin-back branch (scripts/pin-back-pr.sh).
+    # Its PR is opened with GITHUB_TOKEN, which fires no pull_request run,
+    # and workflow_dispatch check runs do not satisfy the main Ruleset's
+    # required checks — so the deploy-key push to this branch is what has
+    # to run CI. Keep it listed here.
+    branches: [main, ci/pins]
   pull_request:
   # Manual runs exist for the deploy gate: Deploy polls for a CI run on
-  # its commit, but a workflow_dispatch deploy from a "[skip ci]"
-  # digest-pin HEAD has none and would time out after 30 minutes.
-  # Dispatching CI on the same commit gives the gate something green.
+  # its commit; if a HEAD somehow has none (an older "[skip ci]" pin
+  # commit, say) the gate would time out after 30 minutes. Dispatching CI
+  # on the same commit gives it something green.
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,12 @@ name: Deploy
 on:
   push:
     branches: [main]
+    # The pin-back PR (scripts/pin-back-pr.sh) lands a commit that touches
+    # only this file. It matches no paths-filter below, so the run would
+    # build and deploy nothing — skip it outright instead of burning a
+    # ci-gate wait. A commit that changes this file AND code still runs.
+    paths-ignore:
+      - 'k8s/kustomization.yaml'
   workflow_dispatch:
     inputs:
       rebuild:
@@ -259,22 +265,24 @@ jobs:
   # `ci/pins` branch — never a direct push: the `main` Ruleset requires a
   # PR + green checks, and a direct push failed with GH013 after an
   # otherwise successful rollout (2026-08-30 ×3, GH #33). The PR auto-merges
-  # (squash) once CI passes; its title carries `[skip ci]` so the resulting
-  # commit does not burn a Deploy run (it matches no paths-filter anyway).
+  # (squash) once CI passes; the push trigger above ignores the resulting
+  # commit. The branch is pushed with the PIN_DEPLOY_KEY deploy key rather
+  # than GITHUB_TOKEN because only a real push fires the CI run whose check
+  # runs the Ruleset counts (workflow_dispatch runs do not — see the script).
   pin-images:
     name: Pin deployed digests back to the repo
     needs: [build-api, build-platform, deploy]
     if: "!cancelled() && needs.deploy.result == 'success'"
     runs-on: ubuntu-latest
     permissions:
-      contents: write        # push the ci/pins branch
+      contents: write        # gh needs it for auto-merge; the push itself uses the deploy key
       pull-requests: write   # open the PR + enable auto-merge
-      actions: write         # dispatch CI on the branch (GITHUB_TOKEN pushes never trigger it)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           fetch-depth: 0             # merge-base / merge need real history
+          ssh-key: ${{ secrets.PIN_DEPLOY_KEY }}   # push over SSH so ci.yml runs on ci/pins
           persist-credentials: true  # the pin-back script pushes
 
       - name: Pin digests via pull request
@@ -289,7 +297,7 @@ jobs:
           # The pin command is re-run on every push retry, so it must be a
           # single idempotent step: both components in one go.
           scripts/pin-back-pr.sh \
-            "ci: pin deployed image digests [skip ci]" \
+            "ci: pin deployed image digests" \
             "Deployed by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}." \
             bash -c '
               set -euo pipefail
@@ -328,13 +336,14 @@ jobs:
     permissions:
       contents: write        # pins the published URL back (ci/pins branch).
       pull-requests: write   # Job-level permissions REPLACE the top-level
-      actions: write         # pair, so WIF's id-token must be respelled
-      id-token: write        # here or the gcloud auth step breaks.
+      id-token: write        # pair, so WIF's id-token must be respelled
+                             # here or the gcloud auth step breaks.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: main
           fetch-depth: 0              # pin-back merges main into ci/pins
+          ssh-key: ${{ secrets.PIN_DEPLOY_KEY }}   # push over SSH so ci.yml runs on ci/pins
           persist-credentials: true   # the pin-back step pushes
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -400,7 +409,7 @@ jobs:
           # jobs run concurrently and the script re-applies on a push race,
           # so neither pin can overwrite the other).
           scripts/pin-back-pr.sh \
-            "ci: pin published banner bundle url [skip ci]" \
+            "ci: pin published banner bundle url" \
             "Published by run ${GITHUB_RUN_ID} from ${GITHUB_SHA}." \
             scripts/pin-banner-url.sh "$URL"
 

--- a/k8s-gke/README.md
+++ b/k8s-gke/README.md
@@ -156,11 +156,21 @@ run while a pin-back PR is still open.
 
 `main` is protected by a Ruleset (pull request + the five CI checks, squash
 merges only). Nothing pushes to it directly — not contributors, not CI. The
-pin-back PR needs two repository settings that are already on: *Allow
-GitHub Actions to create and approve pull requests* and *Allow auto-merge*.
-It uses the default `GITHUB_TOKEN`, whose pushes never trigger workflows,
-so the pin job dispatches `ci.yml` on the branch itself to produce the
-required checks.
+pin-back PR needs two repository settings that are already on (*Allow
+GitHub Actions to create and approve pull requests*, *Allow auto-merge*)
+and one secret: **`PIN_DEPLOY_KEY`**, a write deploy key the pin jobs push
+the `ci/pins` branch with. A push made with `GITHUB_TOKEN` fires no
+workflow, and check runs from a dispatched run do not count toward
+required checks, so without the key the PR opens but never merges. Create
+it once with:
+
+```sh
+scripts/setup-pin-deploy-key.sh
+```
+
+which generates an ed25519 key, registers the public half as a deploy key
+with write access, stores the private half as the secret, and discards it
+locally. Rotate by running it again.
 
 Auth: GCP via Workload Identity Federation (pool `github`, provider
 `github-oidc`, SA `github-deployer@promovolve.iam.gserviceaccount.com`,

--- a/scripts/pin-back-pr.sh
+++ b/scripts/pin-back-pr.sh
@@ -17,26 +17,38 @@
 #   3. commit k8s/kustomization.yaml and push the branch — on rejection
 #      re-fetch and re-run the pin command rather than rebasing a commit,
 #      so a concurrent pin from the OTHER job is never overwritten
-#   4. open the PR if none is open for the branch, dispatch the CI
-#      workflow on it (pushes made with GITHUB_TOKEN do not trigger
-#      `pull_request` runs, and the Ruleset needs those five checks), and
-#      enable auto-merge (squash) so it lands as soon as CI is green
+#   4. open the PR if none is open for the branch and enable auto-merge
+#      (squash) so it lands as soon as the required checks are green
+#
+# THE PUSH MUST NOT USE GITHUB_TOKEN. A push made with the workflow token
+# triggers no workflows, and check runs from a `workflow_dispatch` run do
+# NOT count toward a pull request's required status checks (verified
+# 2026-09-04: six green check runs on the head commit, statusCheckRollup
+# null, PR #41 BLOCKED forever). The pin branch is therefore pushed over
+# SSH with a write deploy key (secret PIN_DEPLOY_KEY, created by
+# scripts/setup-pin-deploy-key.sh; deploy.yml hands it to actions/checkout
+# as `ssh-key`), so the push fires ci.yml's `push` trigger on `ci/pins` and
+# those check runs are the ones the Ruleset counts. `gh` keeps using
+# GITHUB_TOKEN for the PR itself — the "Actions may create pull requests"
+# setting covers that, and auto-merge needs no extra identity.
 #
 # ONE branch, ONE PR: digest and banner pins from the same deploy share it,
 # a rerun finds it already open, and delete-branch-on-merge retires it so
-# the next deploy starts fresh from main. The PR title carries `[skip ci]`
-# so the squash commit it produces does not trigger a Deploy (the change
-# matches no paths-filter anyway, but this saves the run entirely).
+# the next deploy starts fresh from main. The squash commit it lands on
+# main touches only k8s/kustomization.yaml, which deploy.yml's push
+# trigger ignores (`paths-ignore`), so a pin merge never burns a Deploy.
+# No `[skip ci]` anywhere: it would also skip the CI run on the branch.
 #
 #   scripts/pin-back-pr.sh "<commit subject>" "<commit body>" <pin-command...>
 #
-# Requires: gh (authenticated), a checkout with push credentials, and the
-# calling job to hold `contents: write`, `pull-requests: write`, and
-# `actions: write`. Repository settings: "Allow GitHub Actions to create
-# and approve pull requests" and "Allow auto-merge" must be on.
+# Requires: gh (authenticated with GITHUB_TOKEN), a checkout whose origin
+# pushes over SSH with the deploy key, and the calling job to hold
+# `contents: write` and `pull-requests: write`. Repository settings: "Allow
+# GitHub Actions to create and approve pull requests" and "Allow auto-merge"
+# must be on.
 #
 # Idempotent: with nothing to pin it exits 0 without a commit, but still
-# makes sure an open PR (from an earlier job) has CI + auto-merge armed.
+# makes sure an open PR (from an earlier job) has auto-merge armed.
 set -euo pipefail
 
 SUBJECT="${1:?usage: pin-back-pr.sh <commit subject> <commit body> <pin-command...>}"
@@ -47,14 +59,20 @@ shift 2
 BRANCH="${PIN_BRANCH:-ci/pins}"
 BASE="${PIN_BASE:-main}"
 FILE="k8s/kustomization.yaml"
-PR_TITLE="ci: pin deployed digests / banner url [skip ci]"
+PR_TITLE="ci: pin deployed digests / banner url"
 
 cd "$(git rev-parse --show-toplevel)"
+case "$(git remote get-url --push origin)" in
+  git@github.com:*|ssh://*) ;;
+  *) echo "WARNING: origin pushes over HTTPS (GITHUB_TOKEN) — that push triggers no CI run, so the" >&2
+     echo "         pin PR will never satisfy its required checks. Is secret PIN_DEPLOY_KEY set?" >&2
+     echo "         (scripts/setup-pin-deploy-key.sh creates it.)" >&2 ;;
+esac
 git config user.name  "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # --- 1–3. pin, commit, push (retry on a concurrent push) -----------------------
-pushed=0; committed=0
+pushed=0
 for attempt in 1 2 3 4 5; do
   git fetch -q origin "$BASE"
   if git fetch -q origin "$BRANCH" 2>/dev/null; then
@@ -80,7 +98,7 @@ for attempt in 1 2 3 4 5; do
   git add "$FILE"
   git commit -q -m "$SUBJECT" -m "$BODY"
   if git push -q origin "HEAD:refs/heads/$BRANCH"; then
-    pushed=1; committed=1; break
+    pushed=1; break
   fi
   # Someone (the sibling pin job, most likely) pushed first. Drop our commit
   # and re-apply the pin on top of theirs — re-running the pin command is
@@ -97,7 +115,7 @@ if git merge-base --is-ancestor HEAD "origin/$BASE"; then
   exit 0
 fi
 
-# --- 4. PR + CI + auto-merge ---------------------------------------------------
+# --- 4. PR + auto-merge --------------------------------------------------------
 pr=$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json number --jq '.[0].number // empty')
 if [ -z "$pr" ]; then
   pr=$(gh pr create --base "$BASE" --head "$BRANCH" \
@@ -112,14 +130,8 @@ else
   echo "pull request #$pr already open for $BRANCH"
 fi
 
-# Required checks come from the CI workflow, which a GITHUB_TOKEN push never
-# triggers; workflow_dispatch is the sanctioned exception. Its concurrency
-# group cancels a run an earlier pin job started on a stale head. A run that
-# pushed nothing leaves the earlier dispatch (on the same head) alone.
-if [ "$committed" -eq 1 ]; then
-  gh workflow run ci.yml --ref "$BRANCH"
-  echo "dispatched CI on $BRANCH"
-fi
+# The push above (deploy key, not GITHUB_TOKEN) fired ci.yml on the branch;
+# those check runs are what the Ruleset counts. Nothing to dispatch.
 
 # Squash is the only merge method the Ruleset allows. Auto-merge waits for
 # the required checks; a rerun that finds it already enabled is a no-op.

--- a/scripts/setup-pin-deploy-key.sh
+++ b/scripts/setup-pin-deploy-key.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Create (or rotate) the deploy key deploy.yml's pin-back jobs push with.
+#
+# WHY: the pin-back pull request (scripts/pin-back-pr.sh) needs the main
+# Ruleset's required checks on its head commit, and only a real push can
+# produce them — a push made with GITHUB_TOKEN fires no workflow, and check
+# runs from a workflow_dispatch run are not counted (2026-09-04, PR #41 sat
+# BLOCKED with six green check runs). A write deploy key is the smallest
+# identity that pushes like a user: repo-scoped, git-only, no account, no
+# expiry to babysit, and it needs no Ruleset bypass because ci/pins is not
+# a protected branch.
+#
+#   scripts/setup-pin-deploy-key.sh            # this repo (gh's current repo)
+#   scripts/setup-pin-deploy-key.sh owner/repo # a fork
+#
+# Idempotent: re-running replaces both the deploy key and the secret (a
+# rotation). The private key never touches disk outside a mktemp dir that
+# is removed on exit.
+set -euo pipefail
+
+REPO="${1:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+TITLE="deploy.yml pin-back (ci/pins push)"
+SECRET="PIN_DEPLOY_KEY"
+
+command -v gh >/dev/null || { echo "gh is required" >&2; exit 1; }
+command -v ssh-keygen >/dev/null || { echo "ssh-keygen is required" >&2; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+ssh-keygen -q -t ed25519 -N "" -C "$TITLE" -f "$tmp/key"
+
+# Replace an existing key of the same title so a rotation leaves one behind.
+gh repo deploy-key list -R "$REPO" --json id,title --jq ".[] | select(.title==\"$TITLE\") | .id" \
+  | while read -r id; do [ -n "$id" ] && gh repo deploy-key delete -R "$REPO" "$id"; done
+gh repo deploy-key add -R "$REPO" --allow-write --title "$TITLE" "$tmp/key.pub"
+gh secret set "$SECRET" -R "$REPO" < "$tmp/key"
+
+echo "deploy key '$TITLE' registered with write access on $REPO"
+echo "secret $SECRET set; the next deploy's pin-back will push ci/pins with it"


### PR DESCRIPTION
Follow-up to #39 / #33. The first real pin-back PR (#41) got a green CI run via `workflow_dispatch` and still sat `BLOCKED`: GitHub does not count check runs from a dispatched run toward required status checks, and a `GITHUB_TOKEN` push triggers no workflow at all.

## What
- Pin jobs check out with `ssh-key: ${{ secrets.PIN_DEPLOY_KEY }}` and push `ci/pins` over SSH, so the push fires `ci.yml` (`push.branches` now includes `ci/pins`). Those check runs are the ones the Ruleset counts. PR creation and auto-merge stay on `GITHUB_TOKEN`; `actions: write` dropped.
- `scripts/setup-pin-deploy-key.sh`: generates an ed25519 key, registers it as a write deploy key, stores the private half as the secret, rotates on re-run.
- `[skip ci]` removed from pin commits (it would skip the branch CI run). `deploy.yml` uses `paths-ignore: [k8s/kustomization.yaml]` so a pin merge still burns no Deploy.
- `pin-back-pr.sh` warns when origin is HTTPS, i.e. the secret is missing.

## After merge
1. `scripts/setup-pin-deploy-key.sh` once (admin).
2. Next deploy that builds an image pushes onto the existing `ci/pins` (#41 gets a new head, CI runs on push, auto-merge lands it).

https://claude.ai/code/session_016UVYxxNiRjCufNPjzUzDgf