### PR TITLE
ci: pin-back follow-ups from the first live run

### DIFF
--- a/k8s-gke/README.md
+++ b/k8s-gke/README.md
@@ -170,7 +170,10 @@ scripts/setup-pin-deploy-key.sh
 
 which generates an ed25519 key, registers the public half as a deploy key
 with write access, stores the private half as the secret, and discards it
-locally. Rotate by running it again.
+locally. Rotate by running it again. The organization policy *Deploy keys*
+must allow them (`deploy_keys_enabled_for_repositories` on the org; it had
+been switched off on promovolve and was re-enabled 2026-09-04) — the script
+says so if registration is refused.
 
 Auth: GCP via Workload Identity Federation (pool `github`, provider
 `github-oidc`, SA `github-deployer@promovolve.iam.gserviceaccount.com`,

--- a/scripts/pin-back-pr.sh
+++ b/scripts/pin-back-pr.sh
@@ -128,10 +128,18 @@ if [ -z "$pr" ]; then
   echo "opened pull request #$pr"
 else
   echo "pull request #$pr already open for $BRANCH"
+  # A multi-commit PR squashes under its TITLE, so the title must stay clean:
+  # PR #41 was opened by an earlier version with a skip-ci marker in it, which
+  # would have landed on main and starved the next deploy's ci-gate.
+  if [ "$(gh pr view "$pr" --json title --jq .title)" != "$PR_TITLE" ]; then
+    gh pr edit "$pr" --title "$PR_TITLE" >/dev/null && echo "retitled #$pr"
+  fi
 fi
 
-# The push above (deploy key, not GITHUB_TOKEN) fired ci.yml on the branch;
-# those check runs are what the Ruleset counts. Nothing to dispatch.
+# The push above (deploy key, not GITHUB_TOKEN) fired ci.yml on the branch —
+# as a `push` run and, once the PR exists, a `pull_request` run too; both
+# are cheap and the first push of a fresh branch has only the former, which
+# is why ci.yml keeps ci/pins in its push branches. Nothing to dispatch.
 
 # Squash is the only merge method the Ruleset allows. Auto-merge waits for
 # the required checks; a rerun that finds it already enabled is a no-op.

--- a/scripts/setup-pin-deploy-key.sh
+++ b/scripts/setup-pin-deploy-key.sh
@@ -32,7 +32,16 @@ ssh-keygen -q -t ed25519 -N "" -C "$TITLE" -f "$tmp/key"
 # Replace an existing key of the same title so a rotation leaves one behind.
 gh repo deploy-key list -R "$REPO" --json id,title --jq ".[] | select(.title==\"$TITLE\") | .id" \
   | while read -r id; do [ -n "$id" ] && gh repo deploy-key delete -R "$REPO" "$id"; done
-gh repo deploy-key add -R "$REPO" --allow-write --title "$TITLE" "$tmp/key.pub"
+if ! gh repo deploy-key add -R "$REPO" --allow-write --title "$TITLE" "$tmp/key.pub"; then
+  cat >&2 <<EOF
+could not register the deploy key. If GitHub said "Deploy keys are disabled
+for this repository", that is the ORGANIZATION policy (it was off on
+promovolve until 2026-09-04). An org owner turns it on with
+  gh api -X PATCH orgs/${REPO%%/*} -F deploy_keys_enabled_for_repositories=true
+or in the org's Settings > Deploy keys page, then re-run this script.
+EOF
+  exit 1
+fi
 gh secret set "$SECRET" -R "$REPO" < "$tmp/key"
 
 echo "deploy key '$TITLE' registered with write access on $REPO"


### PR DESCRIPTION
Small cleanups found while verifying #43 end to end (deploy run 33878212299 → pin PR #41).

- `pin-back-pr.sh` retitles an already-open pin PR so a multi-commit squash never inherits a stale title (#41 was opened by the first version with a skip-ci marker in it; I renamed it by hand this time).
- `setup-pin-deploy-key.sh` explains the "Deploy keys are disabled for this repository" refusal: it is the org policy `deploy_keys_enabled_for_repositories`, which was off on promovolve and re-enabled today.
- `k8s-gke/README.md` documents that requirement.

https://claude.ai/code/session_016UVYxxNiRjCufNPjzUzDgf