### PR TITLE
ci: run every first-party Go package with the race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,9 @@ jobs:
         with:
           go-version-file: platform/go.mod
           cache-dependency-path: platform/go.sum
-      # Scoped to ./cmd/... and the root package to avoid the Go snippets vendored
-      # under */node_modules by the JS ad-bundle toolchains.
-      - run: go build ./cmd/... .
-      - run: go vet ./cmd/... .
-      - run: go test ./cmd/... .
+      # Build + vet + `go test -race` over every first-party package. The
+      # selection lives in the script (shared with contributors): `go list
+      # ./...` minus the Go snippets npm vendors under */node_modules, which
+      # is what the old `./cmd/... .` scope was dodging — at the price of
+      # never running a single test under internal/ (GH #21).
+      - run: ../scripts/go-test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,9 @@ configuration surface.
 sbt compile
 sbt test                 # all modules; or e.g. `sbt "core/testOnly *FloorSweep*"`
 
-# Go platform
-cd platform
-go build ./...
-go test ./cmd/...        # server + tools
+# Go platform — build + vet + `go test -race` over every first-party package,
+# exactly what CI runs (`scripts/go-test.sh list` prints the package set)
+scripts/go-test.sh
 ```
 
 Notes:
@@ -78,7 +77,9 @@ Notes:
 
 - **Scala** — run `sbt scalafmtAll` before committing (config in
   `.scalafmt.conf`). CI-style check: `sbt scalafmtCheckAll`.
-- **Go** — `gofmt`/`goimports` and `go vet ./...`. Keep to standard Go style.
+- **Go** — `gofmt`/`goimports`; `scripts/go-test.sh` runs `go vet` over the
+  first-party packages (a bare `./...` also sweeps up Go snippets that npm
+  vendors under `node_modules`). Keep to standard Go style.
 - **Match the surrounding code.** Naming, comment density, and idiom should look
   like the file you're editing.
 

--- a/scripts/go-test.sh
+++ b/scripts/go-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build, vet, and race-test every FIRST-PARTY Go package in platform/.
+#
+# WHY THIS EXISTS: the Go CI job ran `go test ./cmd/... .`, and the cmd
+# packages have no tests, so only the root package's tests ever gated a
+# deploy — everything under internal/ (handlers, billing, currency,
+# settings, models, site requests) was invisible to CI (GH #21). The scope
+# had been narrowed because a bare `./...` also picks up Go snippets that
+# npm vendors below node_modules (flatted ships a golang/ port). This is
+# the one place the selection lives: CI and contributors both run it.
+#
+#   scripts/go-test.sh            # build + vet + test -race
+#   scripts/go-test.sh list       # just print the package list
+#
+# Database-backed billing tests skip themselves unless
+# BILLING_TEST_DATABASE_URL is set; making them mandatory is GH #22.
+set -euo pipefail
+
+cd "$(dirname "$0")/../platform"
+
+# Everything the module knows about, minus vendored-by-npm snippets. Kept as
+# a deny-list rather than an allow-list so a new top-level Go directory is
+# tested by default instead of silently skipped.
+pkgs=$(go list ./... | grep -v -E '/(node_modules|\.vite)/')
+
+if [ "${1:-}" = "list" ]; then
+  printf '%s\n' "$pkgs"
+  exit 0
+fi
+
+# shellcheck disable=SC2086  # intentional word-splitting of the package list
+{
+  echo "==> go build ($(printf '%s\n' "$pkgs" | wc -l | tr -d ' ') packages)"
+  go build $pkgs
+  echo "==> go vet"
+  go vet $pkgs
+  echo "==> go test -race"
+  go test -race $pkgs
+}


### PR DESCRIPTION
Closes #21.

## What
- `scripts/go-test.sh`: the single package selection (`go list ./...` minus `node_modules` / `.vite`), then `go build`, `go vet`, `go test -race`. `scripts/go-test.sh list` prints the set.
- `ci.yml` Go job calls the script instead of `go build/vet/test ./cmd/... .`.
- `CONTRIBUTING.md` documents the same command.

## Why
The cmd packages have no tests, so CI only ever ran the root package's tests; nothing under `internal/` gated a deploy. The narrow scope existed to dodge the Go port that the `flatted` npm package vendors under `node_modules`.

## Verified
19 first-party packages, 7 with tests, all pass under `-race` locally in ~16s. DB-backed billing tests still self-skip without `BILLING_TEST_DATABASE_URL` (#22).

https://claude.ai/code/session_016UVYxxNiRjCufNPjzUzDgf