### PR TITLE
feat(core): pure CBO allocator with property tests

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -1,0 +1,399 @@
+package promovolve.advertiser.cbo
+
+import promovolve.publisher.delivery.ThompsonSampling
+
+import scala.util.Random
+
+/**
+ * Campaign Budget Optimization allocator (GH #38, #57).
+ *
+ * Pure function: given the live `auto` campaigns of one advertiser and the
+ * account daily budget, re-splits the remaining account budget into FORWARD
+ * allocations (money each campaign may still spend today) and the daily
+ * budget to push to each campaign (`spent + forward`). No actor, clock,
+ * database or money type here; the entity converts at its boundary.
+ *
+ * Model. Tap-throughs per unit of spend `e_i ~ Gamma(alpha0, beta0)` with
+ * `ctas_i ~ Poisson(e_i * spent_i)`, so the posterior is
+ * `Gamma(alpha0 + ctas_i, beta0 + spent_i)`. One sample per campaign per
+ * tick (Thompson): exploration for free, no epsilon.
+ *
+ * Objective. Returns are concave in spend (more budget wins a campaign's
+ * MARGINAL auctions: higher clearing prices, worse placements), modelled as
+ * `f_i(x) = e_i * x^rho`, `0 < rho < 1`. The KKT condition equalizes the
+ * marginal return `f_i'(x_i) = lambda` across funded campaigns, which under
+ * the box bounds below is a 1-D bisection on `lambda` (water-filling). This
+ * is NOT the greedy "sort by e_i and fill to capacity" vertex: greedy on
+ * SAMPLED rates flips the whole hysteresis band between two equal campaigns
+ * every tick on nothing but sampling noise. `rho -> 1` recovers greedy.
+ *
+ * Bounds per campaign (all on the forward allocation):
+ *   - exploration floor: `explorationFloor * R / N` so a starved campaign
+ *     can always prove itself (budget analogue of the newcomer boost);
+ *   - hysteresis: within `[1 - maxMove, 1 + maxMove]` of the previous
+ *     forward allocation (`dailyBudget - spent`), so a downshift never reads
+ *     as a hard over-pace to the campaign's PI controller;
+ *   - capacity: a campaign whose pace is below `paceBindingThreshold` is
+ *     inventory-limited, and its forward allocation is capped at its own
+ *     projected remaining spend; extra budget would buy nothing.
+ * Never below spent: forward allocations are >= 0 by construction and the
+ * pushed daily budget is `spent + forward` (there is no reservation refund).
+ *
+ * Conservation: `sum(forward) = min(R, sum(upper))` and
+ * `sum(forward) >= min(R, sum(lower))`; when the bounds cannot absorb `R`
+ * the remainder stays under the account wall, which remains the backstop
+ * it is today, and the hysteresis band widens next tick.
+ */
+object CboAllocator {
+
+  /** Gamma prior/posterior on tap-throughs per unit of spend: shape `alpha`, rate `beta`. */
+  final case class GammaPrior(alpha: Double, beta: Double) {
+    require(alpha > 0 && beta > 0, s"GammaPrior needs alpha, beta > 0 (got $alpha, $beta)")
+    def mean: Double = alpha / beta
+
+    /** Posterior after observing `ctas` tap-throughs over `spent` units of spend. */
+    def posterior(ctas: Long, spent: Double): GammaPrior =
+      GammaPrior(alpha + ctas.toDouble, beta + math.max(0.0, spent))
+  }
+
+  object GammaPrior {
+
+    /**
+     * Seed a prior for a new budget day. Mean = yesterday's observed rate when
+     * it rests on at least `minCtas` tap-throughs, else `fallbackRate` (the
+     * campaign's engagement per unit of spend scaled by the account's
+     * CTA-per-engagement ratio, or the network ratio). Strength `beta0` is
+     * the spend equivalent of about half a day at the campaign's rate, so a
+     * fresh campaign is neither ignored nor trusted.
+     */
+    def seed(
+        yesterdayCtas: Long,
+        yesterdaySpent: Double,
+        minCtas: Int,
+        fallbackRate: Double,
+        strengthSpend: Double
+    ): GammaPrior = {
+      val observed = if (yesterdaySpent > 0) yesterdayCtas.toDouble / yesterdaySpent else 0.0
+      val mean     = if (yesterdayCtas >= minCtas && observed > 0) observed else math.max(fallbackRate, MinRate)
+      val beta0    = math.max(strengthSpend, MinStrength)
+      GammaPrior(math.max(mean * beta0, MinShape), beta0)
+    }
+  }
+
+  /** Smallest rate the allocator reasons about; keeps the power law finite. */
+  val MinRate: Double = 1e-9
+
+  /** Floor on prior shape/strength so a posterior is always proper. */
+  val MinShape: Double    = 1e-3
+  val MinStrength: Double = 1e-3
+
+  final case class Params(
+      /** Fraction of the equal share `R / N` every live auto campaign keeps. */
+      explorationFloor: Double = 0.20,
+      /** Max relative move of a forward allocation per tick, both directions. */
+      maxMovePerTick: Double = 0.25,
+      /** Pace at or above this means the pacer is binding: capacity unbounded. */
+      paceBindingThreshold: Double = 0.90,
+      /** Below this elapsed fraction of the day, capacity is unknown: treat as unbounded. */
+      minElapsedFraction: Double = 0.02,
+      /** Concavity of returns in spend: `f(x) = e * x^rho`. */
+      returnsExponent: Double = 0.5,
+      /**
+       * Minimum shape of the Thompson draw. The rate is drawn from
+       * `Gamma(s, s / mean)` with `s = max(alpha, minDrawShape)`: same
+       * posterior mean, coefficient of variation at most `1 / sqrt(s)`.
+       * Creative selection averages thousands of draws per tick; here ONE
+       * draw per campaign per tick moves real money, and under the squared
+       * response (`rho = 0.5`) a draw with 18% spread already swings the
+       * split of two equal campaigns by about 12 points, and even a 4%
+       * spread puts the worst of a day's 96 ticks 8 points off. The
+       * exploration floor guarantees exploration on its own, so the draw
+       * only breaks near-ties: 2048 caps its spread at about 2%.
+       * 0 = pure Thompson.
+       */
+      minDrawShape: Double = 2048.0,
+      /** Posterior decay applied at day roll: `alpha <- factor * (alpha + ctas)`. 0.5 = two-day half-life. */
+      dayRollDecay: Double = 0.5,
+      /** Day-start split = blend * yesterday's final split + (1 - blend) * equal split. */
+      dayStartBlend: Double = 0.20
+  ) {
+    require(explorationFloor >= 0 && explorationFloor <= 1, "explorationFloor in [0,1]")
+    require(maxMovePerTick > 0 && maxMovePerTick < 1, "maxMovePerTick in (0,1)")
+    require(returnsExponent > 0 && returnsExponent < 1, "returnsExponent in (0,1)")
+    require(minDrawShape >= 0, "minDrawShape >= 0")
+    require(dayRollDecay > 0 && dayRollDecay <= 1, "dayRollDecay in (0,1]")
+    require(dayStartBlend >= 0 && dayStartBlend <= 1, "dayStartBlend in [0,1]")
+  }
+
+  /** One live `strategy = auto` campaign as the allocator sees it this tick. */
+  final case class Input[K](
+      id: K,
+      /** Today's spend so far. */
+      spent: Double,
+      /** Today's fraud-filtered tap-throughs. */
+      ctas: Long,
+      /** The daily budget currently configured on the campaign (last push, or its own wall). */
+      dailyBudget: Double,
+      /** Campaign reported `InsufficientBudget` today: the strongest absorb signal. */
+      exhausted: Boolean,
+      prior: GammaPrior,
+      /**
+       * Spend during the last allocator tick, when known. Cumulative pace
+       * cannot tell "just raised, not caught up yet" from "cannot spend";
+       * the last tick's spend against the forward it had is the
+       * instantaneous pace that can. `None` on the first tick of a day.
+       */
+      tickSpend: Option[Double] = None
+  ) {
+    require(spent >= 0 && dailyBudget >= 0 && ctas >= 0, s"Input($id) needs non-negative spend/budget/ctas")
+    require(tickSpend.forall(_ >= 0), s"Input($id) needs non-negative tickSpend")
+
+    /** Forward allocation this campaign currently holds. */
+    def previousForward: Double = math.max(0.0, dailyBudget - spent)
+  }
+
+  final case class Result[K](
+      id: K,
+      /** Money the campaign may still spend today. */
+      forward: Double,
+      /** `spent + forward`: the daily budget to push via UpdateConfig. */
+      newDailyBudget: Double,
+      /** Change of the forward allocation versus the previous tick. */
+      moved: Double,
+      sampledRate: Double,
+      posteriorMean: Double,
+      /** Forward capacity; `Double.PositiveInfinity` when the pacer is binding. */
+      capacity: Double,
+      lower: Double,
+      upper: Double
+  )
+
+  final case class Allocation[K](
+      /** Remaining account budget this tick: `max(0, accountDaily - sum(spent))`. */
+      remaining: Double,
+      /** The multiplier the water-fill settled on; informational. */
+      lambda: Double,
+      results: Vector[Result[K]]
+  ) {
+    def forwardTotal: Double = results.map(_.forward).sum
+  }
+
+  /**
+   * Allocate the remaining account budget across the given campaigns.
+   *
+   * @param accountDaily    the advertiser's daily budget
+   * @param elapsedFraction elapsed fraction of the advertiser-local budget day, in [0, 1]
+   * @param rng             seeded RNG (one Gamma sample per campaign)
+   * @param tickFraction    length of the last allocator tick as a fraction of the day; 0 when
+   *                        unknown (then only cumulative pace informs capacity)
+   */
+  def allocate[K](
+      inputs: Vector[Input[K]],
+      accountDaily: Double,
+      elapsedFraction: Double,
+      rng: Random,
+      params: Params = Params(),
+      tickFraction: Double = 0.0
+  ): Allocation[K] = {
+    val n         = inputs.size
+    val spentSum  = inputs.map(_.spent).sum
+    val remaining = math.max(0.0, accountDaily - spentSum)
+    if (n == 0 || remaining <= 0.0)
+      Allocation(
+        remaining,
+        0.0,
+        inputs.map(i => Result(i.id, 0.0, i.spent, -i.previousForward, 0.0, i.prior.mean, 0.0, 0.0, 0.0))
+      )
+    else {
+      val f     = elapsedFraction.max(0.0).min(1.0)
+      val floor = params.explorationFloor * remaining / n
+
+      val prepared = inputs.map { in =>
+        val post = in.prior.posterior(in.ctas, in.spent)
+        val rate = drawRate(post, rng, params)
+
+        val capacity = capacityOf(in, f, params, tickFraction)
+        val prev     = in.previousForward
+        // Hysteresis band around the previous forward allocation. The upper
+        // bound is never below the floor, so a campaign parked at 0 can grow
+        // again; the lower bound is never above the capacity, so an
+        // inventory-limited campaign is not force-fed.
+        val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick) * prev)
+        val upperRaw = math.max(floor, (1.0 + params.maxMovePerTick) * prev)
+        val upper    = math.min(capacity, upperRaw)
+        val lower    = math.min(lowerRaw, upper)
+        Prep(in, rate, post.mean, capacity, lower, upper)
+      }
+
+      // If the lower bounds alone exceed R, scale them down proportionally;
+      // the sum of allocations can never exceed the remaining account budget.
+      val lowerSum = prepared.map(_.lower).sum
+      val scale    = if (lowerSum > remaining && lowerSum > 0) remaining / lowerSum else 1.0
+      val bounded  = prepared.map(p => p.copy(lower = p.lower * scale, upper = math.max(p.upper, p.lower * scale)))
+
+      val upperSum = bounded.map(_.upper).sum
+      val target   = math.min(remaining, upperSum)
+
+      val (lambda, forwards) =
+        waterFill(bounded.map(p => (p.rate, p.lower, p.upper)), target, params.returnsExponent)
+
+      val results = bounded.zip(forwards).map { case (p, fwd) =>
+        Result(
+          p.in.id,
+          fwd,
+          p.in.spent + fwd,
+          fwd - p.in.previousForward,
+          p.rate,
+          p.posteriorMean,
+          p.capacity,
+          p.lower,
+          p.upper
+        )
+      }
+      Allocation(remaining, lambda, results)
+    }
+  }
+
+  private final case class Prep[K](
+      in: Input[K],
+      rate: Double,
+      posteriorMean: Double,
+      capacity: Double,
+      lower: Double,
+      upper: Double
+  )
+
+  /**
+   * Thompson draw of the tap-through rate from the posterior, with its
+   * shape floored at `params.minDrawShape` (see there). Never below
+   * `MinRate`.
+   */
+  def drawRate(posterior: GammaPrior, rng: Random, params: Params): Double = {
+    val s = math.max(posterior.alpha, params.minDrawShape)
+    math.max(MinRate, ThompsonSampling.sampleGamma(s, rng) * posterior.mean / s)
+  }
+
+  /**
+   * Forward capacity of one campaign; `PositiveInfinity` when more budget
+   * would be spent.
+   *
+   * Two pace readings, and the campaign is pace-binding if EITHER is at or
+   * above the threshold:
+   *   - cumulative: `spent / (dailyBudget * F)`. Alone it cannot tell a
+   *     campaign that was just raised (spend lags the new ceiling) from one
+   *     that cannot spend, and capping the former at its old rate undoes
+   *     every raise the allocator makes.
+   *   - instantaneous, when `tickSpend` is known: last tick's spend against
+   *     the flat-shape slice of the forward it held at the start of that
+   *     tick. Alone it would slash capacity in a quiet hour.
+   * When neither binds the campaign is inventory-limited and its capacity
+   * is the larger of the two projections of its own remaining-day spend.
+   */
+  def capacityOf[K](in: Input[K], elapsedFraction: Double, params: Params, tickFraction: Double = 0.0): Double =
+    if (in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0)
+      Double.PositiveInfinity
+    else {
+      val f              = elapsedFraction
+      val cumulativePace = in.spent / (in.dailyBudget * f)
+      val cumulativeProj = math.max(0.0, in.spent / f - in.spent)
+
+      val instantaneous: Option[(Double, Double)] =
+        for {
+          ts <- in.tickSpend
+          dt <- Option(tickFraction).filter(_ > 0)
+        } yield {
+          val fLast       = math.max(0.0, f - dt)
+          val lastForward = in.previousForward + ts
+          val expected    = if (fLast < 1.0) lastForward * dt / (1.0 - fLast) else 0.0
+          val pace        = if (expected > 0) ts / expected else 0.0
+          val projection  = (ts / dt) * (1.0 - f)
+          (pace, projection)
+        }
+
+      val binding = cumulativePace >= params.paceBindingThreshold ||
+        instantaneous.exists(_._1 >= params.paceBindingThreshold)
+      if (binding) Double.PositiveInfinity
+      else math.max(cumulativeProj, instantaneous.map(_._2).getOrElse(0.0))
+    }
+
+  /**
+   * Water-fill under box bounds. Each campaign's unconstrained response to
+   * the multiplier is `x(lambda) = (rho * e / lambda)^(1 / (1 - rho))`,
+   * clamped to `[lower, upper]`; the sum is non-increasing in `lambda`, so
+   * bisection on `log(lambda)` finds the multiplier whose clamped sum hits
+   * `target`. Returns `(lambda, forwards)`. `target` is clamped into
+   * `[sum(lower), sum(upper)]` defensively.
+   */
+  def waterFill(items: Vector[(Double, Double, Double)], target: Double, rho: Double): (Double, Vector[Double]) = {
+    val lowerSum = items.map(_._2).sum
+    val upperSum = items.map(_._3).sum
+    val t        = target.max(lowerSum).min(upperSum)
+    if (items.isEmpty) (0.0, Vector.empty)
+    else if (t >= upperSum) (0.0, items.map(_._3))
+    else if (t <= lowerSum) (Double.PositiveInfinity, items.map(_._2))
+    else {
+      val inv = 1.0 / (1.0 - rho)
+      def response(rate: Double, lambda: Double): Double = math.pow(rho * rate / lambda, inv)
+      def clampedSum(lambda: Double): Double =
+        items.iterator.map { case (rate, lo, hi) => response(rate, lambda).max(lo).min(hi) }.sum
+
+      // Bracket lambda in log space: at the bracket's low end every campaign
+      // sits at its upper bound, at the high end at its lower bound.
+      var lo = -60.0
+      var hi = 60.0
+      var i  = 0
+      while (i < 200) {
+        val mid = 0.5 * (lo + hi)
+        if (clampedSum(math.exp(mid)) > t) lo = mid else hi = mid
+        i += 1
+      }
+      val lambda   = math.exp(0.5 * (lo + hi))
+      val forwards = items.map { case (rate, lo0, hi0) => response(rate, lambda).max(lo0).min(hi0) }
+      // Bisection leaves a residual of at most the flat parts of the clamped
+      // response; spread it over the campaigns that still have room so the
+      // conservation invariant holds exactly.
+      val residual = t - forwards.sum
+      if (math.abs(residual) < 1e-9) (lambda, forwards)
+      else {
+        val room =
+          if (residual > 0) forwards.zip(items).map { case (x, (_, _, hi0)) => hi0 - x }
+          else forwards.zip(items).map { case (x, (_, lo0, _)) => x - lo0 }
+        val roomSum = room.sum
+        if (roomSum <= 0) (lambda, forwards)
+        else (lambda, forwards.zip(room).map { case (x, r) => x + residual * (r / roomSum) })
+      }
+    }
+  }
+
+  /** Day-roll posterior decay: `Gamma(d * (alpha + ctas), d * (beta + spent))`. */
+  def decayAtDayRoll(prior: GammaPrior, ctas: Long, spent: Double, params: Params = Params()): GammaPrior = {
+    val post = prior.posterior(ctas, spent)
+    GammaPrior(
+      math.max(MinShape, params.dayRollDecay * post.alpha),
+      math.max(MinStrength, params.dayRollDecay * post.beta)
+    )
+  }
+
+  /**
+   * Day-start forward split: yesterday's final split blended with equal
+   * split, scaled to `accountDaily`. Campaigns absent from `yesterdayFinal`
+   * (new today) count as 0 on the yesterday side and 1/N on the equal side.
+   */
+  def dayStartSplit[K](
+      ids: Vector[K],
+      yesterdayFinal: Map[K, Double],
+      accountDaily: Double,
+      params: Params = Params()
+  ): Map[K, Double] = {
+    val n = ids.size
+    if (n == 0 || accountDaily <= 0) Map.empty
+    else {
+      val ySum  = ids.map(id => math.max(0.0, yesterdayFinal.getOrElse(id, 0.0))).sum
+      val blend = if (ySum > 0) params.dayStartBlend else 0.0
+      ids.map { id =>
+        val yShare = if (ySum > 0) math.max(0.0, yesterdayFinal.getOrElse(id, 0.0)) / ySum else 0.0
+        id -> accountDaily * (blend * yShare + (1.0 - blend) / n)
+      }.toMap
+    }
+  }
+}

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -74,8 +74,8 @@ object CboAllocator {
         strengthSpend: Double
     ): GammaPrior = {
       val observed = if (yesterdaySpent > 0) yesterdayCtas.toDouble / yesterdaySpent else 0.0
-      val mean     = if (yesterdayCtas >= minCtas && observed > 0) observed else math.max(fallbackRate, MinRate)
-      val beta0    = math.max(strengthSpend, MinStrength)
+      val mean = if (yesterdayCtas >= minCtas && observed > 0) observed else math.max(fallbackRate, MinRate)
+      val beta0 = math.max(strengthSpend, MinStrength)
       GammaPrior(math.max(mean * beta0, MinShape), beta0)
     }
   }
@@ -84,7 +84,7 @@ object CboAllocator {
   val MinRate: Double = 1e-9
 
   /** Floor on prior shape/strength so a posterior is always proper. */
-  val MinShape: Double    = 1e-3
+  val MinShape: Double = 1e-3
   val MinStrength: Double = 1e-3
 
   final case class Params(
@@ -195,8 +195,8 @@ object CboAllocator {
       params: Params = Params(),
       tickFraction: Double = 0.0
   ): Allocation[K] = {
-    val n         = inputs.size
-    val spentSum  = inputs.map(_.spent).sum
+    val n = inputs.size
+    val spentSum = inputs.map(_.spent).sum
     val remaining = math.max(0.0, accountDaily - spentSum)
     if (n == 0 || remaining <= 0.0)
       Allocation(
@@ -205,7 +205,7 @@ object CboAllocator {
         inputs.map(i => Result(i.id, 0.0, i.spent, -i.previousForward, 0.0, i.prior.mean, 0.0, 0.0, 0.0))
       )
     else {
-      val f     = elapsedFraction.max(0.0).min(1.0)
+      val f = elapsedFraction.max(0.0).min(1.0)
       val floor = params.explorationFloor * remaining / n
 
       val prepared = inputs.map { in =>
@@ -213,26 +213,26 @@ object CboAllocator {
         val rate = drawRate(post, rng, params)
 
         val capacity = capacityOf(in, f, params, tickFraction)
-        val prev     = in.previousForward
+        val prev = in.previousForward
         // Hysteresis band around the previous forward allocation. The upper
         // bound is never below the floor, so a campaign parked at 0 can grow
         // again; the lower bound is never above the capacity, so an
         // inventory-limited campaign is not force-fed.
         val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick) * prev)
         val upperRaw = math.max(floor, (1.0 + params.maxMovePerTick) * prev)
-        val upper    = math.min(capacity, upperRaw)
-        val lower    = math.min(lowerRaw, upper)
+        val upper = math.min(capacity, upperRaw)
+        val lower = math.min(lowerRaw, upper)
         Prep(in, rate, post.mean, capacity, lower, upper)
       }
 
       // If the lower bounds alone exceed R, scale them down proportionally;
       // the sum of allocations can never exceed the remaining account budget.
       val lowerSum = prepared.map(_.lower).sum
-      val scale    = if (lowerSum > remaining && lowerSum > 0) remaining / lowerSum else 1.0
-      val bounded  = prepared.map(p => p.copy(lower = p.lower * scale, upper = math.max(p.upper, p.lower * scale)))
+      val scale = if (lowerSum > remaining && lowerSum > 0) remaining / lowerSum else 1.0
+      val bounded = prepared.map(p => p.copy(lower = p.lower * scale, upper = math.max(p.upper, p.lower * scale)))
 
       val upperSum = bounded.map(_.upper).sum
-      val target   = math.min(remaining, upperSum)
+      val target = math.min(remaining, upperSum)
 
       val (lambda, forwards) =
         waterFill(bounded.map(p => (p.rate, p.lower, p.upper)), target, params.returnsExponent)
@@ -293,7 +293,7 @@ object CboAllocator {
     if (in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0)
       Double.PositiveInfinity
     else {
-      val f              = elapsedFraction
+      val f = elapsedFraction
       val cumulativePace = in.spent / (in.dailyBudget * f)
       val cumulativeProj = math.max(0.0, in.spent / f - in.spent)
 
@@ -302,11 +302,11 @@ object CboAllocator {
           ts <- in.tickSpend
           dt <- Option(tickFraction).filter(_ > 0)
         } yield {
-          val fLast       = math.max(0.0, f - dt)
+          val fLast = math.max(0.0, f - dt)
           val lastForward = in.previousForward + ts
-          val expected    = if (fLast < 1.0) lastForward * dt / (1.0 - fLast) else 0.0
-          val pace        = if (expected > 0) ts / expected else 0.0
-          val projection  = (ts / dt) * (1.0 - f)
+          val expected = if (fLast < 1.0) lastForward * dt / (1.0 - fLast) else 0.0
+          val pace = if (expected > 0) ts / expected else 0.0
+          val projection = (ts / dt) * (1.0 - f)
           (pace, projection)
         }
 
@@ -327,7 +327,7 @@ object CboAllocator {
   def waterFill(items: Vector[(Double, Double, Double)], target: Double, rho: Double): (Double, Vector[Double]) = {
     val lowerSum = items.map(_._2).sum
     val upperSum = items.map(_._3).sum
-    val t        = target.max(lowerSum).min(upperSum)
+    val t = target.max(lowerSum).min(upperSum)
     if (items.isEmpty) (0.0, Vector.empty)
     else if (t >= upperSum) (0.0, items.map(_._3))
     else if (t <= lowerSum) (Double.PositiveInfinity, items.map(_._2))
@@ -341,13 +341,13 @@ object CboAllocator {
       // sits at its upper bound, at the high end at its lower bound.
       var lo = -60.0
       var hi = 60.0
-      var i  = 0
+      var i = 0
       while (i < 200) {
         val mid = 0.5 * (lo + hi)
         if (clampedSum(math.exp(mid)) > t) lo = mid else hi = mid
         i += 1
       }
-      val lambda   = math.exp(0.5 * (lo + hi))
+      val lambda = math.exp(0.5 * (lo + hi))
       val forwards = items.map { case (rate, lo0, hi0) => response(rate, lambda).max(lo0).min(hi0) }
       // Bisection leaves a residual of at most the flat parts of the clamped
       // response; spread it over the campaigns that still have room so the
@@ -388,7 +388,7 @@ object CboAllocator {
     val n = ids.size
     if (n == 0 || accountDaily <= 0) Map.empty
     else {
-      val ySum  = ids.map(id => math.max(0.0, yesterdayFinal.getOrElse(id, 0.0))).sum
+      val ySum = ids.map(id => math.max(0.0, yesterdayFinal.getOrElse(id, 0.0))).sum
       val blend = if (ySum > 0) params.dayStartBlend else 0.0
       ids.map { id =>
         val yShare = if (ySum > 0) math.max(0.0, yesterdayFinal.getOrElse(id, 0.0)) / ySum else 0.0

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -19,26 +19,26 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
 
   private val genPrior: Gen[GammaPrior] =
     for {
-      mean     <- Gen.choose(0.001, 0.2)
+      mean <- Gen.choose(0.001, 0.2)
       strength <- Gen.choose(0.5, 50.0)
     } yield GammaPrior(mean * strength, strength)
 
   private def genInput(id: Int): Gen[Input[Int]] =
     for {
-      budget    <- Gen.choose(0.0, 100.0)
-      spent     <- Gen.choose(0.0, 120.0).map(s => math.min(s, budget * 1.5))
-      ctas      <- Gen.choose(0L, 50L)
+      budget <- Gen.choose(0.0, 100.0)
+      spent <- Gen.choose(0.0, 120.0).map(s => math.min(s, budget * 1.5))
+      ctas <- Gen.choose(0L, 50L)
       exhausted <- Gen.prob(0.15)
-      prior     <- genPrior
+      prior <- genPrior
     } yield Input(id, spent, ctas, budget, exhausted, prior)
 
   private val genCase: Gen[(Vector[Input[Int]], Double, Double, Long)] =
     for {
-      n        <- Gen.choose(1, 6)
-      inputs   <- Gen.sequence[Vector[Input[Int]], Input[Int]]((1 to n).map(genInput))
-      account  <- Gen.choose(0.0, 500.0)
-      elapsed  <- Gen.choose(0.0, 1.0)
-      seed     <- Gen.long
+      n <- Gen.choose(1, 6)
+      inputs <- Gen.sequence[Vector[Input[Int]], Input[Int]]((1 to n).map(genInput))
+      account <- Gen.choose(0.0, 500.0)
+      elapsed <- Gen.choose(0.0, 1.0)
+      seed <- Gen.long
     } yield (inputs, account, elapsed, seed)
 
   private def floorOf(remaining: Double, n: Int, params: Params): Double =
@@ -49,8 +49,8 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
     "conserve the remainder and respect every per-campaign bound" in {
       forAll(genCase) { case (inputs, account, elapsed, seed) =>
         val params = Params()
-        val alloc  = allocate(inputs, account, elapsed, new Random(seed), params)
-        val n      = inputs.size
+        val alloc = allocate(inputs, account, elapsed, new Random(seed), params)
+        val n = inputs.size
 
         alloc.remaining shouldBe math.max(0.0, account - inputs.map(_.spent).sum) +- Eps
         alloc.results.map(_.id) shouldBe inputs.map(_.id)
@@ -79,8 +79,8 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
     "keep the exploration floor and the hysteresis band whenever the remainder can afford them" in {
       forAll(genCase) { case (inputs, account, elapsed, seed) =>
         val params = Params()
-        val alloc  = allocate(inputs, account, elapsed, new Random(seed), params)
-        val n      = inputs.size
+        val alloc = allocate(inputs, account, elapsed, new Random(seed), params)
+        val n = inputs.size
         whenever(alloc.remaining > 0) {
           val floor = floorOf(alloc.remaining, n, params)
           alloc.results.zip(inputs).foreach { case (r, in) =>
@@ -127,12 +127,12 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
 
     "be unbounded when exhausted, early in the day, or pace-binding" in {
       capacityOf(Input(1, 10.0, 0L, 20.0, exhausted = true, GammaPrior(1, 1)), 0.5, params) shouldBe
-        Double.PositiveInfinity
+      Double.PositiveInfinity
       capacityOf(Input(1, 0.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1)), 0.01, params) shouldBe
-        Double.PositiveInfinity
+      Double.PositiveInfinity
       // pace = 10 / (20 * 0.5) = 1.0 >= 0.9
       capacityOf(Input(1, 10.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1)), 0.5, params) shouldBe
-        Double.PositiveInfinity
+      Double.PositiveInfinity
     }
 
     "project the campaign's own remaining day rate when inventory-limited" in {
@@ -144,9 +144,9 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       // Budget raised 20 -> 40 at mid-day: cumulative pace = 10 / (40 * 0.5) = 0.5
       // looks inventory-limited, but the last tick (1/96 of the day) spent the
       // full flat-shape slice of the forward it held: instantaneous pace 1.0.
-      val dt          = 1.0 / 96
+      val dt = 1.0 / 96
       val lastForward = 30.0
-      val slice       = lastForward * dt / (1.0 - (0.5 - dt))
+      val slice = lastForward * dt / (1.0 - (0.5 - dt))
       val in = Input(1, 10.0, 0L, 40.0, exhausted = false, GammaPrior(1, 1), tickSpend = Some(slice))
       capacityOf(in, 0.5, params, dt) shouldBe Double.PositiveInfinity
       // Without the tick reading the old rule would have capped it at its old path.
@@ -169,21 +169,21 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
 
   "CboAllocator.drawRate" should {
     "keep the posterior mean and cap the draw's spread at 1/sqrt(minDrawShape)" in {
-      val rng   = new Random(3L)
-      val post  = GammaPrior(2.0, 40.0) // mean 0.05, only 2 pseudo tap-throughs of evidence
+      val rng = new Random(3L)
+      val post = GammaPrior(2.0, 40.0) // mean 0.05, only 2 pseudo tap-throughs of evidence
       val draws = Vector.fill(4000)(drawRate(post, rng, Params()))
-      val mean  = draws.sum / draws.size
-      val cv    = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
+      val mean = draws.sum / draws.size
+      val cv = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
       mean shouldBe post.mean +- 0.002
       cv should be <= 1.2 / math.sqrt(Params().minDrawShape)
     }
 
     "recover pure Thompson when minDrawShape is 0" in {
-      val rng   = new Random(3L)
-      val post  = GammaPrior(2.0, 40.0)
+      val rng = new Random(3L)
+      val post = GammaPrior(2.0, 40.0)
       val draws = Vector.fill(4000)(drawRate(post, rng, Params(minDrawShape = 0)))
-      val mean  = draws.sum / draws.size
-      val cv    = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
+      val mean = draws.sum / draws.size
+      val cv = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
       cv shouldBe 1.0 / math.sqrt(2.0) +- 0.1
     }
   }
@@ -192,16 +192,16 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
 
     "hit the target exactly and give a higher rate never less money under shared bounds" in {
       val gen = for {
-        n      <- Gen.choose(1, 8)
-        rates  <- Gen.listOfN(n, Gen.choose(0.001, 1.0))
-        lo     <- Gen.choose(0.0, 5.0)
-        hi     <- Gen.choose(5.0, 50.0)
+        n <- Gen.choose(1, 8)
+        rates <- Gen.listOfN(n, Gen.choose(0.001, 1.0))
+        lo <- Gen.choose(0.0, 5.0)
+        hi <- Gen.choose(5.0, 50.0)
         target <- Gen.choose(0.0, 400.0)
       } yield (rates.toVector, lo, hi, target)
 
       forAll(gen) { case (rates, lo, hi, target) =>
-        val items    = rates.map(r => (r, lo, hi))
-        val clamped  = target.max(lo * rates.size).min(hi * rates.size)
+        val items = rates.map(r => (r, lo, hi))
+        val clamped = target.max(lo * rates.size).min(hi * rates.size)
         val (_, out) = waterFill(items, target, 0.5)
         out.sum shouldBe clamped +- 1e-6
         out.foreach { x =>
@@ -252,17 +252,17 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       noiseless: Boolean = false,
       prior: Option[GammaPrior] = None
   ): (Vector[Double], Vector[Long], Vector[Double]) = {
-    val rng      = new Random(seed)
-    val n        = trueRates.size
-    var spent    = Vector.fill(n)(0.0)
+    val rng = new Random(seed)
+    val n = trueRates.size
+    var spent = Vector.fill(n)(0.0)
     var expected = Vector.fill(n)(0.0)
-    var ctas     = Vector.fill(n)(0L)
-    var budgets  = Vector.fill(n)(accountDaily / n)
+    var ctas = Vector.fill(n)(0L)
+    var budgets = Vector.fill(n)(accountDaily / n)
     var lastTick = Vector.fill(n)(Option.empty[Double])
     val p =
       prior.getOrElse(GammaPrior.seed(0L, 0.0, minCtas = 5, fallbackRate = 0.02, strengthSpend = accountDaily / n / 2))
     val shares = Vector.newBuilder[Double]
-    val dt     = 1.0 / ticks
+    val dt = 1.0 / ticks
 
     (0 until ticks).foreach { t =>
       val f = t.toDouble / ticks
@@ -274,7 +274,7 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
         budgets = alloc.results.map(_.newDailyBudget)
       }
       val forward = (0 until n).map(i => math.max(0.0, budgets(i) - spent(i)))
-      val total   = forward.sum
+      val total = forward.sum
       shares += (if (total > 0) forward(0) / total else 0.5)
       val ticksLeft = ticks - t
       (0 until n).foreach { i =>
@@ -321,13 +321,13 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
         shares.last
       }
       val mean = endShares.sum / endShares.size
-      val std  = math.sqrt(endShares.map(s => (s - mean) * (s - mean)).sum / endShares.size)
+      val std = math.sqrt(endShares.map(s => (s - mean) * (s - mean)).sum / endShares.size)
       mean shouldBe 0.5 +- 0.06
       std should be <= 0.2
     }
 
     "move budget toward the campaign with the threefold higher rate without starving the other" in {
-      val params                 = Params()
+      val params = Params()
       val (shares, ctasAuto, sp) = simulateDay(Vector(1.5, 0.5), 100.0, ticks = 96, seed = 7L, fixed = false, params)
       // Converged by the last quarter of the day: A holds a clear majority.
       val lastQuarter = shares.drop(72)
@@ -336,8 +336,8 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       shares.foreach(s => (1 - s) should be >= params.explorationFloor / 2 - 1e-9)
 
       val (_, ctasFixed, _) = simulateDay(Vector(1.5, 0.5), 100.0, ticks = 96, seed = 7L, fixed = true)
-      val autoTotal         = ctasAuto.sum.toDouble
-      val fixedTotal        = ctasFixed.sum.toDouble
+      val autoTotal = ctasAuto.sum.toDouble
+      val fixedTotal = ctasFixed.sum.toDouble
       // Primary gate of #38: tap-throughs per unit of spend up at least 20% over equal split.
       sp.sum shouldBe 100.0 +- 1e-6
       autoTotal / fixedTotal should be >= 1.2

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -1,0 +1,387 @@
+package promovolve.advertiser.cbo
+
+import org.scalacheck.Gen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import promovolve.advertiser.cbo.CboAllocator.*
+
+import scala.util.Random
+
+/**
+ * Property and scenario tests for the pure CBO allocator (GH #57).
+ *
+ * Everything here runs on a seeded RNG: a failure reproduces exactly.
+ */
+class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckPropertyChecks {
+
+  private val Eps = 1e-6
+
+  private val genPrior: Gen[GammaPrior] =
+    for {
+      mean     <- Gen.choose(0.001, 0.2)
+      strength <- Gen.choose(0.5, 50.0)
+    } yield GammaPrior(mean * strength, strength)
+
+  private def genInput(id: Int): Gen[Input[Int]] =
+    for {
+      budget    <- Gen.choose(0.0, 100.0)
+      spent     <- Gen.choose(0.0, 120.0).map(s => math.min(s, budget * 1.5))
+      ctas      <- Gen.choose(0L, 50L)
+      exhausted <- Gen.prob(0.15)
+      prior     <- genPrior
+    } yield Input(id, spent, ctas, budget, exhausted, prior)
+
+  private val genCase: Gen[(Vector[Input[Int]], Double, Double, Long)] =
+    for {
+      n        <- Gen.choose(1, 6)
+      inputs   <- Gen.sequence[Vector[Input[Int]], Input[Int]]((1 to n).map(genInput))
+      account  <- Gen.choose(0.0, 500.0)
+      elapsed  <- Gen.choose(0.0, 1.0)
+      seed     <- Gen.long
+    } yield (inputs, account, elapsed, seed)
+
+  private def floorOf(remaining: Double, n: Int, params: Params): Double =
+    params.explorationFloor * remaining / n
+
+  "CboAllocator.allocate" should {
+
+    "conserve the remainder and respect every per-campaign bound" in {
+      forAll(genCase) { case (inputs, account, elapsed, seed) =>
+        val params = Params()
+        val alloc  = allocate(inputs, account, elapsed, new Random(seed), params)
+        val n      = inputs.size
+
+        alloc.remaining shouldBe math.max(0.0, account - inputs.map(_.spent).sum) +- Eps
+        alloc.results.map(_.id) shouldBe inputs.map(_.id)
+
+        alloc.results.zip(inputs).foreach { case (r, in) =>
+          r.forward should be >= -Eps
+          r.newDailyBudget shouldBe in.spent + r.forward +- Eps
+          r.newDailyBudget should be >= in.spent - Eps // never below spent
+          r.moved shouldBe r.forward - in.previousForward +- Eps
+          if (alloc.remaining > 0) {
+            r.lower should be <= r.upper + Eps
+            r.forward should be >= r.lower - Eps
+            r.forward should be <= r.upper + Eps
+          }
+        }
+
+        if (alloc.remaining > 0) {
+          val upperSum = alloc.results.map(_.upper).sum
+          alloc.forwardTotal shouldBe math.min(alloc.remaining, upperSum) +- 1e-6 * math.max(1.0, alloc.remaining)
+        } else {
+          alloc.results.foreach(_.forward shouldBe 0.0)
+        }
+      }
+    }
+
+    "keep the exploration floor and the hysteresis band whenever the remainder can afford them" in {
+      forAll(genCase) { case (inputs, account, elapsed, seed) =>
+        val params = Params()
+        val alloc  = allocate(inputs, account, elapsed, new Random(seed), params)
+        val n      = inputs.size
+        whenever(alloc.remaining > 0) {
+          val floor = floorOf(alloc.remaining, n, params)
+          alloc.results.zip(inputs).foreach { case (r, in) =>
+            val prev = in.previousForward
+            // Upper: never more than the band above prev, unless the floor is higher.
+            r.forward should be <= math.max(floor, (1 + params.maxMovePerTick) * prev) + Eps
+            // Capacity caps the upper bound whenever it is finite.
+            if (r.capacity.isFinite) r.forward should be <= r.capacity + Eps
+          }
+          // Lower bounds only bind when their (unscaled) sum fits into the
+          // remainder; the result carries the scaled bound, so recompute.
+          val unscaledLowers = alloc.results.zip(inputs).map { case (r, in) =>
+            math.min(math.max(floor, (1 - params.maxMovePerTick) * in.previousForward), r.upper)
+          }
+          if (unscaledLowers.sum <= alloc.remaining + Eps) {
+            alloc.results.zip(unscaledLowers).foreach { case (r, lower) =>
+              r.forward should be >= lower - Eps
+            }
+          }
+        }
+      }
+    }
+
+    "return zero forward allocations when the account is spent" in {
+      val inputs = Vector(
+        Input(1, 60.0, 5L, 70.0, false, GammaPrior(1, 10)),
+        Input(2, 50.0, 1L, 55.0, false, GammaPrior(1, 10))
+      )
+      val alloc = allocate(inputs, 100.0, 0.7, new Random(1))
+      alloc.remaining shouldBe 0.0
+      alloc.results.map(_.forward) shouldBe Vector(0.0, 0.0)
+      alloc.results.map(_.newDailyBudget) shouldBe Vector(60.0, 50.0)
+    }
+
+    "handle an empty campaign set" in {
+      val alloc = allocate(Vector.empty[Input[Int]], 100.0, 0.5, new Random(1))
+      alloc.results shouldBe empty
+      alloc.remaining shouldBe 100.0
+    }
+  }
+
+  "CboAllocator.capacityOf" should {
+    val params = Params()
+
+    "be unbounded when exhausted, early in the day, or pace-binding" in {
+      capacityOf(Input(1, 10.0, 0L, 20.0, exhausted = true, GammaPrior(1, 1)), 0.5, params) shouldBe
+        Double.PositiveInfinity
+      capacityOf(Input(1, 0.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1)), 0.01, params) shouldBe
+        Double.PositiveInfinity
+      // pace = 10 / (20 * 0.5) = 1.0 >= 0.9
+      capacityOf(Input(1, 10.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1)), 0.5, params) shouldBe
+        Double.PositiveInfinity
+    }
+
+    "project the campaign's own remaining day rate when inventory-limited" in {
+      // pace = 4 / (20 * 0.5) = 0.4 < 0.9: it would spend 8 over the day, 4 already gone.
+      capacityOf(Input(1, 4.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1)), 0.5, params) shouldBe 4.0 +- Eps
+    }
+
+    "not cap a campaign that was just raised and is spending at its new rate" in {
+      // Budget raised 20 -> 40 at mid-day: cumulative pace = 10 / (40 * 0.5) = 0.5
+      // looks inventory-limited, but the last tick (1/96 of the day) spent the
+      // full flat-shape slice of the forward it held: instantaneous pace 1.0.
+      val dt          = 1.0 / 96
+      val lastForward = 30.0
+      val slice       = lastForward * dt / (1.0 - (0.5 - dt))
+      val in = Input(1, 10.0, 0L, 40.0, exhausted = false, GammaPrior(1, 1), tickSpend = Some(slice))
+      capacityOf(in, 0.5, params, dt) shouldBe Double.PositiveInfinity
+      // Without the tick reading the old rule would have capped it at its old path.
+      capacityOf(in.copy(tickSpend = None), 0.5, params, dt) shouldBe 10.0 +- Eps
+    }
+
+    "not slash capacity in a quiet tick when the day so far is on pace" in {
+      // On pace cumulatively (pace 1.0), nothing spent in the last tick.
+      val in = Input(1, 10.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1), tickSpend = Some(0.0))
+      capacityOf(in, 0.5, params, 1.0 / 96) shouldBe Double.PositiveInfinity
+    }
+
+    "take the larger projection when genuinely inventory-limited" in {
+      // Cumulative: 4 / 0.5 - 4 = 4. Instantaneous: spending 0.05 per tick of
+      // 1/96 -> 4.8 per day, 0.5 of the day left -> 2.4. Larger wins: 4.
+      val in = Input(1, 4.0, 0L, 20.0, exhausted = false, GammaPrior(1, 1), tickSpend = Some(0.05))
+      capacityOf(in, 0.5, params, 1.0 / 96) shouldBe 4.0 +- Eps
+    }
+  }
+
+  "CboAllocator.drawRate" should {
+    "keep the posterior mean and cap the draw's spread at 1/sqrt(minDrawShape)" in {
+      val rng   = new Random(3L)
+      val post  = GammaPrior(2.0, 40.0) // mean 0.05, only 2 pseudo tap-throughs of evidence
+      val draws = Vector.fill(4000)(drawRate(post, rng, Params()))
+      val mean  = draws.sum / draws.size
+      val cv    = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
+      mean shouldBe post.mean +- 0.002
+      cv should be <= 1.2 / math.sqrt(Params().minDrawShape)
+    }
+
+    "recover pure Thompson when minDrawShape is 0" in {
+      val rng   = new Random(3L)
+      val post  = GammaPrior(2.0, 40.0)
+      val draws = Vector.fill(4000)(drawRate(post, rng, Params(minDrawShape = 0)))
+      val mean  = draws.sum / draws.size
+      val cv    = math.sqrt(draws.map(d => (d - mean) * (d - mean)).sum / draws.size) / mean
+      cv shouldBe 1.0 / math.sqrt(2.0) +- 0.1
+    }
+  }
+
+  "CboAllocator.waterFill" should {
+
+    "hit the target exactly and give a higher rate never less money under shared bounds" in {
+      val gen = for {
+        n      <- Gen.choose(1, 8)
+        rates  <- Gen.listOfN(n, Gen.choose(0.001, 1.0))
+        lo     <- Gen.choose(0.0, 5.0)
+        hi     <- Gen.choose(5.0, 50.0)
+        target <- Gen.choose(0.0, 400.0)
+      } yield (rates.toVector, lo, hi, target)
+
+      forAll(gen) { case (rates, lo, hi, target) =>
+        val items    = rates.map(r => (r, lo, hi))
+        val clamped  = target.max(lo * rates.size).min(hi * rates.size)
+        val (_, out) = waterFill(items, target, 0.5)
+        out.sum shouldBe clamped +- 1e-6
+        out.foreach { x =>
+          x should be >= lo - Eps
+          x should be <= hi + Eps
+        }
+        val sortedByRate = rates.zip(out).sortBy(_._1)
+        sortedByRate.zip(sortedByRate.tail).foreach { case ((_, x1), (_, x2)) =>
+          x2 should be >= x1 - 1e-6
+        }
+      }
+    }
+
+    "equalize marginal return between two unbounded campaigns: split proportional to rate^(1/(1-rho))" in {
+      // rho = 0.5 -> x_i proportional to e_i^2; 3x rate gap -> 9:1 split.
+      val (_, out) = waterFill(Vector((0.03, 0.0, 1e9), (0.01, 0.0, 1e9)), 100.0, 0.5)
+      out(0) shouldBe 90.0 +- 1e-4
+      out(1) shouldBe 10.0 +- 1e-4
+    }
+  }
+
+  /** Knuth's Poisson sampler; lambda is small here. */
+  private def poisson(lambda: Double, rng: Random): Long = {
+    val l = math.exp(-lambda)
+    var k = 0L
+    var p = 1.0
+    while ({ p *= rng.nextDouble(); p > l }) k += 1
+    k
+  }
+
+  /**
+   * Day simulation: `ticks` allocator ticks over one budget day. Each tick
+   * every campaign spends the slice of its forward allocation due by the
+   * next tick (it paces to its own wall) and earns tap-throughs at its true
+   * rate: Poisson by default, or the deterministic expectation (tracked as
+   * a real-valued accumulator, floored to a count) when `noiseless`.
+   * Returns the per-tick forward shares of campaign A, the day's
+   * tap-through totals and the day's spend. `fixed = true` freezes an
+   * equal split; `prior` defaults to a cold day-1 prior.
+   */
+  private def simulateDay(
+      trueRates: Vector[Double],
+      accountDaily: Double,
+      ticks: Int,
+      seed: Long,
+      fixed: Boolean,
+      params: Params = Params(),
+      noiseless: Boolean = false,
+      prior: Option[GammaPrior] = None
+  ): (Vector[Double], Vector[Long], Vector[Double]) = {
+    val rng      = new Random(seed)
+    val n        = trueRates.size
+    var spent    = Vector.fill(n)(0.0)
+    var expected = Vector.fill(n)(0.0)
+    var ctas     = Vector.fill(n)(0L)
+    var budgets  = Vector.fill(n)(accountDaily / n)
+    var lastTick = Vector.fill(n)(Option.empty[Double])
+    val p =
+      prior.getOrElse(GammaPrior.seed(0L, 0.0, minCtas = 5, fallbackRate = 0.02, strengthSpend = accountDaily / n / 2))
+    val shares = Vector.newBuilder[Double]
+    val dt     = 1.0 / ticks
+
+    (0 until ticks).foreach { t =>
+      val f = t.toDouble / ticks
+      if (!fixed) {
+        val inputs = (0 until n).toVector.map { i =>
+          Input(i, spent(i), ctas(i), budgets(i), exhausted = false, p, tickSpend = lastTick(i))
+        }
+        val alloc = allocate(inputs, accountDaily, f, rng, params, tickFraction = dt)
+        budgets = alloc.results.map(_.newDailyBudget)
+      }
+      val forward = (0 until n).map(i => math.max(0.0, budgets(i) - spent(i)))
+      val total   = forward.sum
+      shares += (if (total > 0) forward(0) / total else 0.5)
+      val ticksLeft = ticks - t
+      (0 until n).foreach { i =>
+        val slice = forward(i) / ticksLeft
+        spent = spent.updated(i, spent(i) + slice)
+        lastTick = lastTick.updated(i, Some(slice))
+        if (noiseless) {
+          expected = expected.updated(i, expected(i) + trueRates(i) * slice)
+          ctas = ctas.updated(i, math.round(expected(i)))
+        } else ctas = ctas.updated(i, ctas(i) + poisson(trueRates(i) * slice, rng))
+      }
+    }
+    (shares.result(), ctas, spent)
+  }
+
+  "CboAllocator over a simulated day" should {
+
+    "inject no noise of its own: two equal campaigns with equal data stay within 15% of an equal split" in {
+      // Noiseless (rounded expected) counts isolate the allocator's own
+      // randomness, the Thompson draw, from Poisson noise in the data.
+      // Day-2 prior: on a cold prior worth half a pseudo tap-through the
+      // FIRST count to land is a threefold rate difference, so integer
+      // rounding alone decides the morning; that is data quantization, not
+      // the draw, and day 1 is warm-up by design (#38).
+      val prior = GammaPrior.seed(25L, 50.0, minCtas = 5, fallbackRate = 0.02, strengthSpend = 25.0)
+      val (shares, _, _) =
+        simulateDay(Vector(0.5, 0.5), 100.0, ticks = 96, seed = 42L, fixed = false, noiseless = true,
+          prior = Some(prior))
+      shares.foreach(s => s shouldBe 0.5 +- 0.075)
+      val mean = shares.sum / shares.size
+      mean shouldBe 0.5 +- 0.02
+    }
+
+    "track Poisson noise in the data without running away (symmetric-rate control across seeds)" in {
+      // Day 2: prior seeded from yesterday's equal rates at half-day
+      // strength; ~25 tap-throughs per campaign per day. The split follows
+      // the cumulative count ratio (any responsive allocator does), so per
+      // tick it wanders, but across seeds it is centred and bounded.
+      val prior = GammaPrior.seed(25L, 50.0, minCtas = 5, fallbackRate = 0.02, strengthSpend = 25.0)
+      val endShares = (1 to 30).map { seed =>
+        val (shares, _, _) =
+          simulateDay(Vector(0.5, 0.5), 100.0, ticks = 96, seed = seed.toLong, fixed = false, prior = Some(prior))
+        shares.foreach(s => s shouldBe 0.5 +- 0.35)
+        shares.last
+      }
+      val mean = endShares.sum / endShares.size
+      val std  = math.sqrt(endShares.map(s => (s - mean) * (s - mean)).sum / endShares.size)
+      mean shouldBe 0.5 +- 0.06
+      std should be <= 0.2
+    }
+
+    "move budget toward the campaign with the threefold higher rate without starving the other" in {
+      val params                 = Params()
+      val (shares, ctasAuto, sp) = simulateDay(Vector(1.5, 0.5), 100.0, ticks = 96, seed = 7L, fixed = false, params)
+      // Converged by the last quarter of the day: A holds a clear majority.
+      val lastQuarter = shares.drop(72)
+      lastQuarter.sum / lastQuarter.size should be >= 0.7
+      // B never drops below its exploration floor of the equal share.
+      shares.foreach(s => (1 - s) should be >= params.explorationFloor / 2 - 1e-9)
+
+      val (_, ctasFixed, _) = simulateDay(Vector(1.5, 0.5), 100.0, ticks = 96, seed = 7L, fixed = true)
+      val autoTotal         = ctasAuto.sum.toDouble
+      val fixedTotal        = ctasFixed.sum.toDouble
+      // Primary gate of #38: tap-throughs per unit of spend up at least 20% over equal split.
+      sp.sum shouldBe 100.0 +- 1e-6
+      autoTotal / fixedTotal should be >= 1.2
+    }
+  }
+
+  "GammaPrior.seed" should {
+    "use yesterday's rate when it rests on enough tap-throughs, else the fallback" in {
+      val fromData = GammaPrior.seed(40L, 200.0, minCtas = 10, fallbackRate = 0.05, strengthSpend = 100.0)
+      fromData.mean shouldBe 0.2 +- Eps
+      fromData.beta shouldBe 100.0
+
+      val sparse = GammaPrior.seed(3L, 200.0, minCtas = 10, fallbackRate = 0.05, strengthSpend = 100.0)
+      sparse.mean shouldBe 0.05 +- Eps
+    }
+  }
+
+  "decayAtDayRoll" should {
+    "fold in the day and halve the evidence" in {
+      val next = decayAtDayRoll(GammaPrior(2.0, 10.0), ctas = 6L, spent = 30.0)
+      next.alpha shouldBe 4.0 +- Eps
+      next.beta shouldBe 20.0 +- Eps
+      next.mean shouldBe 0.2 +- Eps
+    }
+  }
+
+  "dayStartSplit" should {
+    "blend yesterday's final split 20/80 with equal split and sum to the account budget" in {
+      val split = dayStartSplit(Vector("a", "b"), Map("a" -> 90.0, "b" -> 10.0), 100.0)
+      split("a") shouldBe (0.2 * 0.9 + 0.8 * 0.5) * 100 +- Eps
+      split("b") shouldBe (0.2 * 0.1 + 0.8 * 0.5) * 100 +- Eps
+      split.values.sum shouldBe 100.0 +- Eps
+    }
+
+    "give a campaign new today its equal share of the 80%" in {
+      val split = dayStartSplit(Vector("a", "b", "c"), Map("a" -> 60.0, "b" -> 40.0), 90.0)
+      split("c") shouldBe 0.8 / 3 * 90 +- Eps
+      split.values.sum shouldBe 90.0 +- Eps
+    }
+
+    "fall back to an equal split when there is no yesterday" in {
+      val split = dayStartSplit(Vector("a", "b"), Map.empty[String, Double], 50.0)
+      split("a") shouldBe 25.0 +- Eps
+      split("b") shouldBe 25.0 +- Eps
+    }
+  }
+}


### PR DESCRIPTION
Closes #57. Second PR toward #38 (Campaign Budget Optimization). Pure function only: no AdvertiserEntity wiring, no persisted strategy field, no stats read, no dashboard. Nothing in production calls it yet.

## What

`promovolve.advertiser.cbo.CboAllocator.allocate(inputs, accountDaily, elapsedFraction, rng, params, tickFraction)` takes one advertiser's live `auto` campaigns (today's spend, tap-throughs, current daily budget, exhausted flag, Gamma prior, last tick's spend) and returns each campaign's forward allocation and the daily budget to push (`spent + forward`), plus the sampled rate, posterior mean, capacity and bounds for the "moved +Z" explanation.

- **Posterior:** `Gamma(alpha0 + ctas, beta0 + spent)` on tap-throughs per unit of spend, one draw per campaign per tick.
- **Objective:** concave returns `f_i(x) = e_i * x^rho` (default `rho = 0.5`), water-fill on the shared multiplier under box bounds. `sum(forward) = min(R, sum(upper))`; `rho -> 1` recovers greedy.
- **Bounds:** exploration floor 20% of equal share; hysteresis 25% per tick both ways; capacity for inventory-limited campaigns; never below spent.
- **Day-roll helpers:** prior seed (yesterday's rate above a minimum count, else the engagement-derived fallback, at half-day strength), decay with a two-day half-life, 20/80 blend of yesterday's final split with equal split.

## Three findings the tests forced, all of which change #38

1. **Greedy is wrong, as the issue itself argues one paragraph earlier.** The worked allocation step in #38 says "sort by sampled rate, fill each to capacity". That is the LP vertex the same section rejects. On sampled rates it flips the entire hysteresis band between two equal campaigns every tick. This PR implements the concave water-fill the issue's reasoning calls for.
2. **One Thompson draw per tick cannot be raw.** Creative selection averages thousands of draws per tick; here one draw moves real money. Under the squared response, an 18% draw spread swings the split of two equal campaigns by about 12 points, and even a 4% spread puts the worst tick of a day 8 points off. `Params.minDrawShape` (default 2048, about 2% spread) floors the draw's shape; 0 recovers pure Thompson. The exploration floor carries exploration on its own.
3. **Cumulative pace cannot drive capacity.** A campaign that was just raised looks under-paced until its spend catches up, and the cumulative rule caps it back at its old rate, undoing every raise; the split then drifts. The allocator now also takes last tick's spend and uses instantaneous pace: a campaign is pace-binding if either reading is at or above the threshold, and an inventory-limited campaign's capacity is the larger of the two projections, so a quiet hour does not slash it either. The entity will need to carry per-campaign spend at the previous tick, which it already observes.

One more property worth knowing for the scenario gate: on a cold prior worth half a pseudo tap-through, the first count that lands is a threefold rate difference, so integer counts alone decide the morning of day 1. That is data, not the allocator, and #38 already treats day 1 as warm-up. With a day-2 prior and about 25 tap-throughs per campaign, the split of two equal campaigns follows the cumulative count ratio, roughly a 0.1 standard deviation by day end. `rho` is the knob that trades convergence speed against that noise; the two-campaign scenario (#55) should set it.

## Tests

21 tests, all seeded, in `CboAllocatorSpec`: conservation and bounds (ScalaCheck), floor and hysteresis when affordable, spent account, empty set, capacity in all four regimes, draw spread bound and pure-Thompson recovery, water-fill exactness and monotonicity, the 9:1 split at a threefold gap, symmetric-rate control with noiseless data (every tick within 15% of equal) and with Poisson data across 30 seeds (centred, bounded), threefold gap convergence over a cold day (majority by the last quarter, weaker campaign never below its floor, at least 20% more tap-throughs than the fixed equal split on the same seed), and the three day-roll helpers.

```
sbt "core/testOnly promovolve.advertiser.cbo.*"   # Tests: succeeded 21, failed 0
```

scalafmt applied and checked.

## Next

Entity wiring (#38): persisted `strategy` on CampaignEntity, `budgetMode` and priors on AdvertiserEntity, the stats read, the tick, and the UpdateConfig push with `budget` omitted from the dashboard patch.

https://claude.ai/code/session_01VjNDM8pNEjbDimNF3McbZy