### PR TITLE
feat(harness): budgetMode scenario key for the CBO gate

### DIFF
--- a/scripts/RunScenario.scala
+++ b/scripts/RunScenario.scala
@@ -116,7 +116,10 @@ object RunScenario {
       // advertiser-level budget/cpm, which is useless for CBO scenarios.
       campaignBudgets: Option[Array[Double]] = None,    // Daily budget per campaign index
       campaignCpms: Option[Array[Double]] = None,       // maxCpm per campaign index
-      campaignStrategies: Option[Array[String]] = None  // bidding.strategy per campaign index: fixed | auto
+      campaignStrategies: Option[Array[String]] = None, // bidding.strategy per campaign index: fixed | auto
+      // Advertiser account budget mode (Campaign Budget Optimization):
+      // "manual" | "optimized". None = leave the account's default (manual).
+      budgetMode: Option[String] = None
   ) {
     /** True when any campaign can produce tap-throughs. */
     def ctaEnabled: Boolean = ctaRate > 0 || ctaRates.exists(_.exists(_ > 0))
@@ -289,6 +292,7 @@ object RunScenario {
       | Adv Budget:  $$${effectiveAdvBudget} per advertiser$advBudgetNote
       | CPM:         ${config.cpms.map(arr => arr.map(c => f"$$$c%.2f").mkString(", ")).getOrElse(f"$$${config.cpm}%.2f")}
       | Day length:  $dayDurationDisplay (${config.dayDurationSeconds}s)
+      | Budget mode: ${config.budgetMode.getOrElse("manual (default)")}
       | Tap-through: ${if (config.ctaEnabled) (1 to config.campaignsPerAdvertiser).map(n => f"camp$n=${config.ctaRateFor(n) * 100}%.0f%%").mkString(", ") + " of clicks" else "off (no /cta beacons)"}
       |==========================================
       |""".stripMargin)
@@ -307,10 +311,11 @@ object RunScenario {
       // campaignBudgets the siblings differ, so sum the per-index values.
       val campaignWalls = (1 to config.campaignsPerAdvertiser).map(n => config.campaignBudgetFor(n, campBudget))
       val advBudget = config.advertiserBudget.getOrElse(campaignWalls.sum)
+      val budgetModeJson = config.budgetMode.map(m => s""", "budgetMode": "$m"""").getOrElse("")
       basicRequest
         .put(uri"${config.baseUrl}/v1/advertisers/$advId/budget")
         .header("Content-Type", "application/json")
-        .body(s"""{"dailyBudget": "$advBudget"}""")
+        .body(s"""{"dailyBudget": "$advBudget"$budgetModeJson}""")
         .send(backend)
 
       for (campNum <- 1 to config.campaignsPerAdvertiser) {
@@ -2160,6 +2165,7 @@ object RunScenario {
       |  "campaignBudgets": [10, 10]    Daily budget per campaign index (advertiser wall = sum unless advertiserBudget set)
       |  "campaignCpms": [5, 5]         maxCpm per campaign index
       |  "campaignStrategies": ["auto", "auto"]  bidding.strategy per campaign index (fixed | auto)
+      |  "budgetMode": "optimized"      Advertiser account budget mode (manual | optimized); needed for auto campaigns to be re-split
       |
       |Examples:
       |  # Pacing test with scenario file
@@ -2270,6 +2276,13 @@ object RunScenario {
         case arr if arr.nonEmpty => Some(arr)
         case _ => None
       }
+      val budgetMode = extractString(json, "budgetMode") match {
+        case "" => None
+        case m if m == "manual" || m == "optimized" => Some(m)
+        case bad =>
+          println(s"Error: budgetMode must be manual or optimized (got: $bad)")
+          sys.exit(1)
+      }
       val campaignStrategies = parseStringArray(json, "campaignStrategies") match {
         case Nil => None
         case l =>
@@ -2312,7 +2325,8 @@ object RunScenario {
         ctaDelayMs = ctaDelayMs,
         campaignBudgets = campaignBudgets,
         campaignCpms = campaignCpms,
-        campaignStrategies = campaignStrategies
+        campaignStrategies = campaignStrategies,
+        budgetMode = budgetMode
       )
     } finally {
       source.close()

--- a/scripts/scenarios/cbo-two-campaign-fixed.json
+++ b/scripts/scenarios/cbo-two-campaign-fixed.json
@@ -31,7 +31,8 @@
       0.3,
       0.1
     ],
-    "ctaDelayMs": 150
+    "ctaDelayMs": 150,
+    "budgetMode": "manual"
   },
   "pacing": {
     "dayDurationSeconds": 300,

--- a/scripts/scenarios/cbo-two-campaign.json
+++ b/scripts/scenarios/cbo-two-campaign.json
@@ -1,6 +1,6 @@
 {
   "name": "CBO Two-Campaign (auto)",
-  "description": "Campaign Budget Optimization gate: both campaigns strategy=auto so the allocator may move budget. One advertiser, account budget 20, two campaigns with identical CPM and targeting but a 3x tap-through gap (30% vs 10% of clicks). 3 simulated days of 300s (day 1 is warm-up). Compare account tap-throughs per unit of spend and the per-campaign budget trace against the -fixed control. Gate for #38.",
+  "description": "Campaign Budget Optimization gate: both campaigns strategy=auto and the account in optimized budget mode so the allocator moves budget. Run the server with SIM_DAY_DURATION_SECONDS=300 CBO_TICK_INTERVAL=3s (96 ticks per simulated day). One advertiser, account budget 20, two campaigns with identical CPM and targeting but a 3x tap-through gap (30% vs 10% of clicks). 3 simulated days of 300s (day 1 is warm-up). Compare account tap-throughs per unit of spend and the per-campaign budget trace against the -fixed control. Gate for #38.",
   "setup": {
     "mode": "pacing",
     "advertisers": 1,
@@ -31,7 +31,8 @@
       0.3,
       0.1
     ],
-    "ctaDelayMs": 150
+    "ctaDelayMs": 150,
+    "budgetMode": "optimized"
   },
   "pacing": {
     "dayDurationSeconds": 300,


### PR DESCRIPTION
Closes #77. Adds the one missing harness knob for the Campaign Budget Optimization gate: a `budgetMode` scenario key (`manual` | `optimized`, absent = unchanged) sent with the advertiser daily-budget PUT. `cbo-two-campaign.json` sets it to `optimized` and documents the server env it needs (`SIM_DAY_DURATION_SECONDS=300 CBO_TICK_INTERVAL=3s`); the `-fixed` control stays manual.

Compiled with `scala-cli compile scripts/RunScenario.scala`. Verified end to end on the dev cluster: the api log shows `Budget mode for advertiser adv-1-...: 'manual' -> 'optimized'` on the PUT, and the allocator starts pushing budgets.

The gate run itself is not in this PR: the first run exposed an allocator bug (a zero-spend campaign is cut below its exploration floor and oscillates), tracked separately. The gate result will be posted on #38 once that fix is deployed.

https://claude.ai/code/session_01VjNDM8pNEjbDimNF3McbZy