### PR TITLE
fix(cbo): floor beats capacity, and capacity needs account spend evidence

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -96,6 +96,13 @@ object CboAllocator {
       paceBindingThreshold: Double = 0.90,
       /** Below this elapsed fraction of the day, capacity is unknown: treat as unbounded. */
       minElapsedFraction: Double = 0.02,
+      /**
+       * Until the pool has spent this fraction of the account daily budget,
+       * capacity is unknown for everyone: "no spend yet" is not evidence that
+       * a campaign cannot spend (day start, a quiet night). Without this a
+       * zero-spend campaign read as inventory-limited with zero capacity.
+       */
+      minPoolSpendFraction: Double = 0.02,
       /** Concavity of returns in spend: `f(x) = e * x^rho`. */
       returnsExponent: Double = 0.5,
       /**
@@ -121,6 +128,7 @@ object CboAllocator {
     require(maxMovePerTick > 0 && maxMovePerTick < 1, "maxMovePerTick in (0,1)")
     require(returnsExponent > 0 && returnsExponent < 1, "returnsExponent in (0,1)")
     require(minDrawShape >= 0, "minDrawShape >= 0")
+    require(minPoolSpendFraction >= 0 && minPoolSpendFraction < 1, "minPoolSpendFraction in [0,1)")
     require(dayRollDecay > 0 && dayRollDecay <= 1, "dayRollDecay in (0,1]")
     require(dayStartBlend >= 0 && dayStartBlend <= 1, "dayStartBlend in [0,1]")
   }
@@ -207,20 +215,24 @@ object CboAllocator {
     else {
       val f = elapsedFraction.max(0.0).min(1.0)
       val floor = params.explorationFloor * remaining / n
+      // Capacity needs evidence: enough of the day AND enough account spend.
+      val capacityKnown = f >= params.minElapsedFraction &&
+        spentSum >= params.minPoolSpendFraction * accountDaily
 
       val prepared = inputs.map { in =>
         val post = in.prior.posterior(in.ctas, in.spent)
         val rate = drawRate(post, rng, params)
 
-        val capacity = capacityOf(in, f, params, tickFraction)
+        val capacity = if (capacityKnown) capacityOf(in, f, params, tickFraction) else Double.PositiveInfinity
         val prev = in.previousForward
-        // Hysteresis band around the previous forward allocation. The upper
-        // bound is never below the floor, so a campaign parked at 0 can grow
-        // again; the lower bound is never above the capacity, so an
-        // inventory-limited campaign is not force-fed.
+        // Hysteresis band around the previous forward allocation, then the
+        // capacity cap, then the floor as a HARD lower bound: the exploration
+        // floor is the design's invariant (#38) and beats capacity. Letting
+        // capacity win cut a zero-spend campaign to 0, which then read as
+        // exhausted, got the floor back, and oscillated every tick (#79).
         val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick) * prev)
         val upperRaw = math.max(floor, (1.0 + params.maxMovePerTick) * prev)
-        val upper = math.min(capacity, upperRaw)
+        val upper = math.max(floor, math.min(capacity, upperRaw))
         val lower = math.min(lowerRaw, upper)
         Prep(in, rate, post.mean, capacity, lower, upper)
       }

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -87,8 +87,8 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
             val prev = in.previousForward
             // Upper: never more than the band above prev, unless the floor is higher.
             r.forward should be <= math.max(floor, (1 + params.maxMovePerTick) * prev) + Eps
-            // Capacity caps the upper bound whenever it is finite.
-            if (r.capacity.isFinite) r.forward should be <= r.capacity + Eps
+            // Capacity caps the upper bound whenever it is finite, but never below the floor.
+            if (r.capacity.isFinite) r.forward should be <= math.max(r.capacity, floor) + Eps
           }
           // Lower bounds only bind when their (unscaled) sum fits into the
           // remainder; the result carries the scaled bound, so recompute.
@@ -102,6 +102,48 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
           }
         }
       }
+    }
+
+    "keep a zero-spend campaign at its exploration floor instead of cutting it to zero (#79)" in {
+      // Mid-day, sibling spending on pace, this one has not spent at all:
+      // inventory-limited with zero projected capacity. It must still keep
+      // the floor, and hold it tick after tick without oscillating.
+      val params = Params()
+      var budgetA = 50.0
+      var pushes = 0
+      (1 to 20).foreach { t =>
+        val inputs = Vector(
+          Input(1, 0.0, 0L, budgetA, exhausted = budgetA <= 0.0, GammaPrior(1, 10)),
+          Input(2, 25.0 + t * 0.5, 5L, 50.0 + t * 0.5, exhausted = false, GammaPrior(1, 10), tickSpend = Some(0.5))
+        )
+        val alloc = allocate(inputs, 100.0, 0.5 + t * 0.005, new Random(t.toLong), params, tickFraction = 1.0 / 96)
+        val ra = alloc.results.find(_.id == 1).get
+        val floor = params.explorationFloor * alloc.remaining / 2
+        ra.forward should be >= floor - Eps
+        ra.newDailyBudget should be >= floor - Eps
+        // Anything beyond the floor's own drift (the remainder shrinks 0.5 per
+        // tick, so the floor moves 0.05) is a flip.
+        if (t > 1 && math.abs(ra.newDailyBudget - budgetA) > 0.1) pushes += 1
+        budgetA = ra.newDailyBudget
+      }
+      // The first tick steps it down toward the floor (bounded by hysteresis);
+      // after that nothing flips back and forth.
+      pushes shouldBe 0
+      budgetA should be > 0.0
+      budgetA should be < 15.0
+    }
+
+    "not infer capacity while the account has barely spent (quiet start)" in {
+      // 1% of the account budget spent by one campaign, none by the other:
+      // no campaign may be capped yet, so the zero-spend one keeps its wall
+      // (hysteresis aside), not just the floor.
+      val inputs = Vector(
+        Input(1, 0.0, 0L, 50.0, exhausted = false, GammaPrior(1, 10)),
+        Input(2, 1.0, 0L, 50.0, exhausted = false, GammaPrior(1, 10))
+      )
+      val alloc = allocate(inputs, 100.0, 0.3, new Random(1))
+      alloc.results.foreach(_.capacity shouldBe Double.PositiveInfinity)
+      alloc.results.find(_.id == 1).get.forward should be >= 0.75 * 50.0 - Eps
     }
 
     "return zero forward allocations when the account is spent" in {


### PR DESCRIPTION
Closes #79. Found by the first Campaign Budget Optimization gate run on the dev cluster (#77, #38).

## What went wrong

A campaign with no spend yet has cumulative pace 0, so the allocator read it as inventory-limited with a projected remaining spend of 0. Capacity was allowed to override the exploration floor, so its forward allocation became 0 and its daily budget was pushed to `spent + 0`. On the next snapshot it reported exhausted (budget equals spend), which made capacity unbounded again, so it was handed the floor back. Then it had near-zero spend again, and the cycle repeated every tick:

```
campaign ...E54N: dailyBudget -> 2.0000 (moved +2.0000 forward ...)
campaign ...DVC9: dailyBudget -> 0.0000 (moved -2.0000 forward ...)
campaign ...E54N: dailyBudget -> 0.0000 (moved -2.0000 forward ...)
```

Both campaigns sat at or below the floor for the whole warm-up. The clock guard only covers the first 2% of the day, so in production this would hit any campaign that has not spent after midnight while a sibling has.

## Fix

- **The floor is a hard lower bound**, as #38 states: `upper = max(floor, min(capacity, hysteresisUpper))`. An inventory-limited campaign is cut to the floor, and no further.
- **Capacity needs evidence.** Until the pool has spent `minPoolSpendFraction` (2%) of the account daily budget, capacity is unknown for everyone. No traffic yet is not evidence that a campaign cannot spend. This covers day start and quiet nights; the elapsed-fraction guard stays too.

## Tests

`CboAllocatorSpec`: 35 pass. New: a zero-spend campaign next to a spending sibling keeps its floor across 20 ticks with zero flips after the first step; a quiet account infers no capacity and the zero-spend campaign keeps its wall within hysteresis. The bounds property now checks `forward <= max(capacity, floor)`.

scalafmt run with a cleared cache.

## Next

Deploy, point the dev cluster at the new api digest, rerun `cbo-two-campaign` and its fixed control, post results on #38.

https://claude.ai/code/session_01VjNDM8pNEjbDimNF3McbZy