### PR TITLE
fix(cbo): bound capacity cuts by hysteresis, probe gently, trust only settled walls

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
@@ -352,6 +352,7 @@ object AdvertiserEntity {
     val priors = CboPlanner.rollPriors(rolled.priorsForCbo, eph.lastSnapshots)
     eph.lastSpent = Map.empty
     eph.lastSnapshots = Vector.empty
+    eph.cappedLast = Set.empty
     eph.dayStartPending = rolled.budgetMode == CboBudgetMode.Optimized
     rolled.withCboPriors(priors)
   }
@@ -434,10 +435,16 @@ object AdvertiserEntity {
           tickFraction = cboCtx.tickInterval.toMillis / 1000.0 / dayLength,
           lastSpent = eph.lastSpent,
           dayStartPending = eph.dayStartPending,
-          rng = eph.rng
+          rng = eph.rng,
+          tick = eph.tick,
+          lastPushTick = eph.lastPushTick,
+          cappedLast = eph.cappedLast
         )
         eph.lastSpent = snapshots.map(s => s.campaignId -> s.spent).toMap
         eph.lastSnapshots = snapshots
+        eph.lastPushTick = eph.lastPushTick ++ plan.pushes.map(p => p.campaignId -> eph.tick)
+        eph.cappedLast = plan.capped
+        eph.tick += 1
         if (plan.dayStartApplied) eph.dayStartPending = false
 
         val pushBudgets = () =>
@@ -901,11 +908,18 @@ object AdvertiserEntity {
     var lastSpent: Map[CampaignId, Double] = Map.empty
     var lastSnapshots: Vector[CboPlanner.Snapshot] = Vector.empty
     var dayStartPending: Boolean = false
+
+    /** Tick ordinal in this incarnation; walls pushed within settleTicks of it are not trusted for capacity (#82). */
+    var tick: Long = 0L
+    var lastPushTick: Map[CampaignId, Long] = Map.empty
+    var cappedLast: Set[CampaignId] = Set.empty
     val rng: Random = new Random()
     def reset(): Unit = {
       lastSpent = Map.empty
       lastSnapshots = Vector.empty
       dayStartPending = false
+      lastPushTick = Map.empty
+      cappedLast = Set.empty
     }
   }
 

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -103,6 +103,21 @@ object CboAllocator {
        * zero-spend campaign read as inventory-limited with zero capacity.
        */
       minPoolSpendFraction: Double = 0.02,
+      /**
+       * Raise step for a campaign that was capacity-capped on the previous
+       * tick. Probing whether a capped campaign can absorb more is inherent
+       * (a wall cut to capacity reads as binding), so the probe must stay
+       * inside what the pacer shrugs off (#82).
+       */
+      probeStep: Double = 0.10,
+      /**
+       * Ticks a wall must have been stable before a pace reading against
+       * it is trusted for capacity. Measuring pace against a wall the
+       * allocator itself just moved made the capacity estimate
+       * self-fulfilling: cut, braked pacer, less spend, lower capacity,
+       * cut again (#82).
+       */
+      settleTicks: Int = 2,
       /** Concavity of returns in spend: `f(x) = e * x^rho`. */
       returnsExponent: Double = 0.5,
       /**
@@ -129,6 +144,8 @@ object CboAllocator {
     require(returnsExponent > 0 && returnsExponent < 1, "returnsExponent in (0,1)")
     require(minDrawShape >= 0, "minDrawShape >= 0")
     require(minPoolSpendFraction >= 0 && minPoolSpendFraction < 1, "minPoolSpendFraction in [0,1)")
+    require(probeStep > 0 && probeStep <= maxMovePerTick, "probeStep in (0, maxMovePerTick]")
+    require(settleTicks >= 0, "settleTicks >= 0")
     require(dayRollDecay > 0 && dayRollDecay <= 1, "dayRollDecay in (0,1]")
     require(dayStartBlend >= 0 && dayStartBlend <= 1, "dayStartBlend in [0,1]")
   }
@@ -151,7 +168,15 @@ object CboAllocator {
        * the last tick's spend against the forward it had is the
        * instantaneous pace that can. `None` on the first tick of a day.
        */
-      tickSpend: Option[Double] = None
+      tickSpend: Option[Double] = None,
+      /** This campaign's forward allocation was capacity-capped on the previous tick: raise by `probeStep` only. */
+      cappedLastTick: Boolean = false,
+      /**
+       * The wall has been stable for at least `settleTicks` ticks. While
+       * false, capacity is not inferred: no cut, and a raise only when the
+       * campaign is pace-binding against the wall it has.
+       */
+      wallSettled: Boolean = true
   ) {
     require(spent >= 0 && dailyBudget >= 0 && ctas >= 0, s"Input($id) needs non-negative spend/budget/ctas")
     require(tickSpend.forall(_ >= 0), s"Input($id) needs non-negative tickSpend")
@@ -170,10 +195,12 @@ object CboAllocator {
       moved: Double,
       sampledRate: Double,
       posteriorMean: Double,
-      /** Forward capacity; `Double.PositiveInfinity` when the pacer is binding. */
+      /** Forward capacity; `Double.PositiveInfinity` when the pacer is binding or not inferred. */
       capacity: Double,
       lower: Double,
-      upper: Double
+      upper: Double,
+      /** Capacity bound the raise this tick (feeds next tick's `cappedLastTick`). */
+      capped: Boolean = false
   )
 
   final case class Allocation[K](
@@ -223,18 +250,30 @@ object CboAllocator {
         val post = in.prior.posterior(in.ctas, in.spent)
         val rate = drawRate(post, rng, params)
 
-        val capacity = if (capacityKnown) capacityOf(in, f, params, tickFraction) else Double.PositiveInfinity
         val prev = in.previousForward
-        // Hysteresis band around the previous forward allocation, then the
-        // capacity cap, then the floor as a HARD lower bound: the exploration
-        // floor is the design's invariant (#38) and beats capacity. Letting
-        // capacity win cut a zero-spend campaign to 0, which then read as
-        // exhausted, got the floor back, and oscillated every tick (#79).
+        // Hysteresis band around the previous forward allocation. Cuts and
+        // raises are both bounded by the band (#82: an unbounded capacity
+        // cut wound up the pacer and blacked out the campaign); a campaign
+        // capped last tick probes upward by the smaller probeStep. The floor
+        // is a HARD lower bound (#38, #79).
+        val raiseStep = if (in.cappedLastTick) params.probeStep else params.maxMovePerTick
         val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick) * prev)
-        val upperRaw = math.max(floor, (1.0 + params.maxMovePerTick) * prev)
-        val upper = math.max(floor, math.min(capacity, upperRaw))
-        val lower = math.min(lowerRaw, upper)
-        Prep(in, rate, post.mean, capacity, lower, upper)
+        val upperRaw = math.max(floor, (1.0 + raiseStep) * prev)
+        val (capacity, capped, lower, upper) =
+          if (!capacityKnown) (Double.PositiveInfinity, false, lowerRaw, upperRaw)
+          else if (!in.wallSettled) {
+            // The wall moved within settleTicks: any pace reading is the echo
+            // of that move. Hold the allocation; allow a raise only when the
+            // campaign is binding against the wall it has now.
+            val hold = math.max(lowerRaw, math.min(prev, upperRaw))
+            if (paceBinding(in, f, params, tickFraction)) (Double.PositiveInfinity, false, hold, upperRaw)
+            else (Double.PositiveInfinity, false, hold, hold)
+          } else {
+            val cap = capacityOf(in, f, params, tickFraction)
+            val up = math.max(lowerRaw, math.min(cap, upperRaw))
+            (cap, cap < upperRaw, math.min(lowerRaw, up), up)
+          }
+        Prep(in, rate, post.mean, capacity, lower, upper, capped)
       }
 
       // If the lower bounds alone exceed R, scale them down proportionally;
@@ -259,7 +298,8 @@ object CboAllocator {
           p.posteriorMean,
           p.capacity,
           p.lower,
-          p.upper
+          p.upper,
+          p.capped
         )
       }
       Allocation(remaining, lambda, results)
@@ -272,7 +312,8 @@ object CboAllocator {
       posteriorMean: Double,
       capacity: Double,
       lower: Double,
-      upper: Double
+      upper: Double,
+      capped: Boolean
   )
 
   /**
@@ -305,28 +346,44 @@ object CboAllocator {
     if (in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0)
       Double.PositiveInfinity
     else {
-      val f = elapsedFraction
-      val cumulativePace = in.spent / (in.dailyBudget * f)
-      val cumulativeProj = math.max(0.0, in.spent / f - in.spent)
-
-      val instantaneous: Option[(Double, Double)] =
-        for {
-          ts <- in.tickSpend
-          dt <- Option(tickFraction).filter(_ > 0)
-        } yield {
-          val fLast = math.max(0.0, f - dt)
-          val lastForward = in.previousForward + ts
-          val expected = if (fLast < 1.0) lastForward * dt / (1.0 - fLast) else 0.0
-          val pace = if (expected > 0) ts / expected else 0.0
-          val projection = (ts / dt) * (1.0 - f)
-          (pace, projection)
-        }
-
-      val binding = cumulativePace >= params.paceBindingThreshold ||
-        instantaneous.exists(_._1 >= params.paceBindingThreshold)
+      val (binding, cumulativeProj, instProj) = paceReadings(in, elapsedFraction, params, tickFraction)
       if (binding) Double.PositiveInfinity
-      else math.max(cumulativeProj, instantaneous.map(_._2).getOrElse(0.0))
+      else math.max(cumulativeProj, instProj)
     }
+
+  /** True when the campaign's spend is held back by its wall (either pace reading at or above the threshold). */
+  def paceBinding[K](in: Input[K], elapsedFraction: Double, params: Params, tickFraction: Double = 0.0): Boolean =
+    in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0 ||
+    paceReadings(in, elapsedFraction, params, tickFraction)._1
+
+  /** (binding, cumulative projection, instantaneous projection) of remaining-day spend. */
+  private def paceReadings[K](
+      in: Input[K],
+      elapsedFraction: Double,
+      params: Params,
+      tickFraction: Double
+  ): (Boolean, Double, Double) = {
+    val f = elapsedFraction
+    val cumulativePace = in.spent / (in.dailyBudget * f)
+    val cumulativeProj = math.max(0.0, in.spent / f - in.spent)
+
+    val instantaneous: Option[(Double, Double)] =
+      for {
+        ts <- in.tickSpend
+        dt <- Option(tickFraction).filter(_ > 0)
+      } yield {
+        val fLast = math.max(0.0, f - dt)
+        val lastForward = in.previousForward + ts
+        val expected = if (fLast < 1.0) lastForward * dt / (1.0 - fLast) else 0.0
+        val pace = if (expected > 0) ts / expected else 0.0
+        val projection = (ts / dt) * (1.0 - f)
+        (pace, projection)
+      }
+
+    val binding = cumulativePace >= params.paceBindingThreshold ||
+      instantaneous.exists(_._1 >= params.paceBindingThreshold)
+    (binding, cumulativeProj, instantaneous.map(_._2).getOrElse(0.0))
+  }
 
   /**
    * Water-fill under box bounds. Each campaign's unconstrained response to

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
@@ -43,7 +43,9 @@ object CboPlanner {
       /** True when this plan applied the day-start split (so the pending flag can clear). */
       dayStartApplied: Boolean,
       /** Human-readable reason when nothing was pushed. */
-      note: String
+      note: String,
+      /** Campaigns whose raise was capacity-capped this tick (next tick probes gently). */
+      capped: Set[CampaignId] = Set.empty
   )
 
   /** Minimum number of live auto campaigns for the allocator to do anything. */
@@ -90,6 +92,9 @@ object CboPlanner {
    *
    * @param lastSpent       each campaign's spend as of the previous tick (for instantaneous pace)
    * @param dayStartPending true on the first tick after a budget-day roll: push the 20/80 split
+   * @param tick            this tick's ordinal in the entity's incarnation
+   * @param lastPushTick    the tick each campaign's wall was last pushed (for `wallSettled`)
+   * @param cappedLast      campaigns capacity-capped on the previous tick (for `cappedLastTick`)
    */
   def plan(
       snapshots: Vector[Snapshot],
@@ -100,7 +105,10 @@ object CboPlanner {
       lastSpent: Map[CampaignId, Double],
       dayStartPending: Boolean,
       rng: Random,
-      params: Params = Params()
+      params: Params = Params(),
+      tick: Long = 0L,
+      lastPushTick: Map[CampaignId, Long] = Map.empty,
+      cappedLast: Set[CampaignId] = Set.empty
   ): Plan = {
     val pool = eligible(snapshots)
     if (pool.size < MinCampaigns)
@@ -139,7 +147,9 @@ object CboPlanner {
             dailyBudget = s.dailyBudget,
             exhausted = s.exhausted,
             prior = seeded(s.campaignId),
-            tickSpend = lastSpent.get(s.campaignId).map(prev => math.max(0.0, s.spent - prev))
+            tickSpend = lastSpent.get(s.campaignId).map(prev => math.max(0.0, s.spent - prev)),
+            cappedLastTick = cappedLast.contains(s.campaignId),
+            wallSettled = lastPushTick.get(s.campaignId).forall(t => tick - t >= params.settleTicks)
           )
         }
         val alloc = CboAllocator.allocate(inputs, accountDaily, elapsedFraction, rng, params, tickFraction)
@@ -150,7 +160,7 @@ object CboPlanner {
           else Some(Push(r.id, r.newDailyBudget, r.moved, r.sampledRate, r.posteriorMean))
         }
         val note = if (pushes.isEmpty) f"no move (remaining ${alloc.remaining}%.4f)" else ""
-        Plan(pushes, seeded, dayStartApplied = false, note)
+        Plan(pushes, seeded, dayStartApplied = false, note, alloc.results.filter(_.capped).map(_.id).toSet)
       }
     }
   }

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -87,8 +87,10 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
             val prev = in.previousForward
             // Upper: never more than the band above prev, unless the floor is higher.
             r.forward should be <= math.max(floor, (1 + params.maxMovePerTick) * prev) + Eps
-            // Capacity caps the upper bound whenever it is finite, but never below the floor.
-            if (r.capacity.isFinite) r.forward should be <= math.max(r.capacity, floor) + Eps
+            // Capacity caps the raise whenever it is finite, but a cut is bounded by
+            // the band (#82) and never goes below the floor.
+            if (r.capacity.isFinite)
+              r.forward should be <= math.max(math.max(r.capacity, floor), (1 - params.maxMovePerTick) * prev) + Eps
           }
           // Lower bounds only bind when their (unscaled) sum fits into the
           // remainder; the result carries the scaled bound, so recompute.
@@ -121,16 +123,55 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
         val floor = params.explorationFloor * alloc.remaining / 2
         ra.forward should be >= floor - Eps
         ra.newDailyBudget should be >= floor - Eps
-        // Anything beyond the floor's own drift (the remainder shrinks 0.5 per
-        // tick, so the floor moves 0.05) is a flip.
-        if (t > 1 && math.abs(ra.newDailyBudget - budgetA) > 0.1) pushes += 1
+        // Bounded cuts (#82) walk it down 25% per tick; a raise would be a flip.
+        if (ra.newDailyBudget > budgetA + 1e-6) pushes += 1
         budgetA = ra.newDailyBudget
       }
-      // The first tick steps it down toward the floor (bounded by hysteresis);
-      // after that nothing flips back and forth.
+      // It never rises, and it reaches the floor within the 20 ticks.
       pushes shouldBe 0
       budgetA should be > 0.0
       budgetA should be < 15.0
+    }
+
+    "cut an inventory-limited campaign no faster than the band, and probe a capped one gently (#82)" in {
+      val params = Params()
+      // Settled wall, spending 4 of 40 by mid-day: capacity 4, far below the
+      // 30 the band allows; the cut stops at the band.
+      val limited = Input(1, 4.0, 1L, 44.0, exhausted = false, GammaPrior(1, 10), tickSpend = Some(0.02))
+      val other = Input(2, 25.0, 5L, 50.0, exhausted = false, GammaPrior(1, 10), tickSpend = Some(0.5))
+      val a1 = allocate(Vector(limited, other), 100.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
+      val r1 = a1.results.find(_.id == 1).get
+      r1.capacity should be < 30.0
+      r1.forward shouldBe (1 - params.maxMovePerTick) * 40.0 +- Eps
+      r1.capped shouldBe true
+
+      // Same campaign, capped last tick and now pace-binding: the raise is probeStep, not maxMovePerTick.
+      val probing = Input(1, 20.0, 1L, 50.0, exhausted = false, GammaPrior(5, 10), tickSpend = Some(0.7),
+        cappedLastTick = true)
+      val a2 = allocate(Vector(probing, other.copy(prior = GammaPrior(1, 100))), 100.0, 0.5, new Random(1), params,
+        tickFraction = 1.0 / 96)
+      val r2 = a2.results.find(_.id == 1).get
+      r2.forward should be <= (1 + params.probeStep) * 30.0 + Eps
+      r2.forward should be > 30.0
+    }
+
+    "hold an unsettled wall unless the campaign is binding against it (#82)" in {
+      val params = Params()
+      // Wall moved last tick; spend since then is a trickle: not binding -> frozen at prev.
+      val unsettled = Input(1, 10.0, 3L, 40.0, exhausted = false, GammaPrior(5, 10), tickSpend = Some(0.01),
+        wallSettled = false)
+      val other = Input(2, 25.0, 1L, 50.0, exhausted = false, GammaPrior(1, 100), tickSpend = Some(0.5))
+      val a1 = allocate(Vector(unsettled, other), 100.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
+      val r1 = a1.results.find(_.id == 1).get
+      r1.forward shouldBe 30.0 +- Eps
+      r1.capacity shouldBe Double.PositiveInfinity
+      // Same wall, but it spent its whole slice: binding -> may rise, still within the band.
+      val slice = 30.0 * (1.0 / 96) / 0.5
+      val binding = unsettled.copy(spent = 10.0 + slice, dailyBudget = 40.0 + slice, tickSpend = Some(slice))
+      val a2 = allocate(Vector(binding, other), 100.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
+      val r2 = a2.results.find(_.id == 1).get
+      r2.forward should be > 30.0
+      r2.forward should be <= (1 + params.maxMovePerTick) * 30.0 + Eps
     }
 
     "not infer capacity while the account has barely spent (quiet start)" in {

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
@@ -3,7 +3,7 @@ package promovolve.advertiser.cbo
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import promovolve.CampaignId
-import promovolve.advertiser.cbo.CboAllocator.GammaPrior
+import promovolve.advertiser.cbo.CboAllocator.{ GammaPrior, Params }
 import promovolve.advertiser.cbo.CboPlanner.*
 
 import java.time.Instant
@@ -127,6 +127,22 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
       val aWithout = without.pushes.find(_.campaignId == ca).map(_.newDailyBudget).getOrElse(60.0)
       aWith should be >= aWithout - Eps
       aWith should be > 60.0
+    }
+  }
+
+  "CboPlanner.plan with wall memory (#82)" should {
+    "hold a campaign whose wall was pushed within settleTicks and report capped campaigns" in {
+      // b is inventory-limited (1 of 40 spent at mid-day) and would be cut when settled.
+      val priors = Map(ca -> GammaPrior(6.0, 20.0), cb -> GammaPrior(1.0, 20.0))
+      val snaps = Vector(snap(ca, 60, 30, 6), snap(cb, 41, 1, 0))
+      val last = Map(ca -> 30.0, cb -> 1.0)
+      val settled = plan(snaps, priors, 100.0, 0.5, 1.0 / 96, last, false, new Random(1), Params(), tick = 10L)
+      settled.pushes.find(_.campaignId == cb).map(_.newDailyBudget).getOrElse(41.0) should be < 41.0
+      settled.capped should contain(cb)
+
+      val held = plan(snaps, priors, 100.0, 0.5, 1.0 / 96, last, false, new Random(1), Params(),
+        tick = 10L, lastPushTick = Map(cb -> 9L))
+      held.pushes.find(_.campaignId == cb) shouldBe None
     }
   }
 

--- a/scripts/scenarios/cbo-two-campaign-scarce-fixed.json
+++ b/scripts/scenarios/cbo-two-campaign-scarce-fixed.json
@@ -1,0 +1,74 @@
+{
+  "name": "CBO Two-Campaign scarce (fixed control)",
+  "description": "Control for cbo-two-campaign-scarce: account budget 10, both campaigns fixed at 5, manual account.",
+  "setup": {
+    "mode": "pacing",
+    "advertisers": 1,
+    "campaignsPerAdvertiser": 2,
+    "creativesPerCampaign": 2,
+    "adProductCategory": "1529",
+    "additionalCategories": [
+      "653",
+      "654",
+      "655"
+    ],
+    "budget": 5.0,
+    "campaignBudgets": [
+      5.0,
+      5.0
+    ],
+    "advertiserBudget": 10.0,
+    "cpm": 5.0,
+    "campaignCpms": [
+      5.0,
+      5.0
+    ],
+    "campaignStrategies": [
+      "fixed",
+      "fixed"
+    ],
+    "ctaRates": [
+      0.3,
+      0.1
+    ],
+    "ctaDelayMs": 150,
+    "budgetMode": "manual"
+  },
+  "pacing": {
+    "dayDurationSeconds": 300,
+    "weekdayShapeVolumes": [
+      0.5,
+      0.3,
+      0.2,
+      0.2,
+      0.3,
+      0.5,
+      0.8,
+      1.5,
+      2.0,
+      2.5,
+      2.5,
+      2.0,
+      1.8,
+      2.0,
+      2.2,
+      2.5,
+      3.0,
+      2.5,
+      2.0,
+      1.5,
+      1.0,
+      0.8,
+      0.6,
+      0.4
+    ]
+  },
+  "traffic": {
+    "continuous": true,
+    "reportEvery": 400,
+    "clickRate": 0.05,
+    "variableDelay": false,
+    "delayMs": 10,
+    "stopAfterDays": 3
+  }
+}

--- a/scripts/scenarios/cbo-two-campaign-scarce.json
+++ b/scripts/scenarios/cbo-two-campaign-scarce.json
@@ -1,0 +1,74 @@
+{
+  "name": "CBO Two-Campaign scarce (auto)",
+  "description": "Demand-scarce variant of cbo-two-campaign: account budget 10 with 5 + 5 walls, below the ~7/day each campaign spends unconstrained (measured in the fixed control of gate run 1), so the walls bind and moving budget can change spend. Both campaigns auto, account optimized. Same 3x tap-through gap, 3 days of 300s. Compare with -scarce-fixed.",
+  "setup": {
+    "mode": "pacing",
+    "advertisers": 1,
+    "campaignsPerAdvertiser": 2,
+    "creativesPerCampaign": 2,
+    "adProductCategory": "1529",
+    "additionalCategories": [
+      "653",
+      "654",
+      "655"
+    ],
+    "budget": 5.0,
+    "campaignBudgets": [
+      5.0,
+      5.0
+    ],
+    "advertiserBudget": 10.0,
+    "cpm": 5.0,
+    "campaignCpms": [
+      5.0,
+      5.0
+    ],
+    "campaignStrategies": [
+      "auto",
+      "auto"
+    ],
+    "ctaRates": [
+      0.3,
+      0.1
+    ],
+    "ctaDelayMs": 150,
+    "budgetMode": "optimized"
+  },
+  "pacing": {
+    "dayDurationSeconds": 300,
+    "weekdayShapeVolumes": [
+      0.5,
+      0.3,
+      0.2,
+      0.2,
+      0.3,
+      0.5,
+      0.8,
+      1.5,
+      2.0,
+      2.5,
+      2.5,
+      2.0,
+      1.8,
+      2.0,
+      2.2,
+      2.5,
+      3.0,
+      2.5,
+      2.0,
+      1.5,
+      1.0,
+      0.8,
+      0.6,
+      0.4
+    ]
+  },
+  "traffic": {
+    "continuous": true,
+    "reportEvery": 400,
+    "clickRate": 0.05,
+    "variableDelay": false,
+    "delayMs": 10,
+    "stopAfterDays": 3
+  }
+}


### PR DESCRIPTION
Closes #82. Second allocator fix from the first Campaign Budget Optimization gate run (#38).

## What went wrong

The capacity estimate was self-fulfilling. A capacity cut bypassed the hysteresis band (-39% in one tick), the campaign's pacer read it as hard over-pace and braked, the lower spend read as lower capacity, and the next tick cut it again. Meanwhile the weaker campaign, never braked, absorbed every raise. The control run showed the strong campaign wins 55% of impressions on equal walls, so selection was not the cause. Day 3 ended in a 154 s blackout (6,297 pacing skips, 0 budget exhaustions) and the allocator pushed 40 budgets a minute.

## Fix

- **Cuts respect the band.** `upper = max(lowerRaw, min(capacity, upperRaw))`: a campaign walks down to its capacity at most 25% per tick. (Raises were always bounded.)
- **Gentle probes.** A campaign that was capacity-capped on the previous tick raises by `probeStep` (10%) instead of 25%, so the inherent raise-then-cut probe stays inside what the pacer shrugs off.
- **Only settled walls inform capacity.** No pace reading is trusted against a wall the allocator pushed within `settleTicks` (2). Such a campaign is held at its allocation, and raised only if it is pace-binding against the wall it has. `AdvertiserEntity`'s ephemeral memory now carries the tick ordinal, each campaign's last-push tick, and the capped set; the planner turns those into the allocator's `wallSettled` / `cappedLastTick` inputs.
- `paceBinding` is exposed separately from `capacityOf`; `Result.capped` feeds the next tick.

## Scenarios

`cbo-two-campaign-scarce.json` and `-scarce-fixed.json`: account budget 10 with 5 + 5 walls, below the roughly 7 a day each campaign spent unconstrained in the fixed control, so the walls bind and moving budget can actually change spend. Gate run 1 showed that with 10 + 10 walls neither wall bound most of the day, which makes the equal split a strong baseline by construction.

## Tests

```
sbt "core/testOnly promovolve.advertiser.cbo.*"   # Tests: succeeded 38, failed 0
```

New: an inventory-limited campaign is cut exactly to the band, not to capacity, and is reported capped; a capped campaign's raise is bounded by the probe step; an unsettled wall is held unless binding, and rises within the band when binding; the planner holds a campaign pushed within settleTicks and reports the capped set. The bounds property now allows a bounded cut above capacity. scalafmt run with a cleared cache.

## Next

Deploy, point the dev cluster at the new digest, rerun the four scenarios (original pair and scarce pair), post on #38.

https://claude.ai/code/session_01VjNDM8pNEjbDimNF3McbZy