### PR TITLE
fix(cbo): material pushes only, unsettled walls block capacity cuts only, pool-relative pace

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -118,6 +118,12 @@ object CboAllocator {
        * cut again (#82).
        */
       settleTicks: Int = 2,
+      /**
+       * Smallest push, as a fraction of the current wall. Tie-breaking
+       * moves of a few cents are not worth an UpdateConfig, and a wall
+       * that is pushed every tick never settles (#85).
+       */
+      minPushFraction: Double = 0.01,
       /** Concavity of returns in spend: `f(x) = e * x^rho`. */
       returnsExponent: Double = 0.5,
       /**
@@ -146,6 +152,7 @@ object CboAllocator {
     require(minPoolSpendFraction >= 0 && minPoolSpendFraction < 1, "minPoolSpendFraction in [0,1)")
     require(probeStep > 0 && probeStep <= maxMovePerTick, "probeStep in (0, maxMovePerTick]")
     require(settleTicks >= 0, "settleTicks >= 0")
+    require(minPushFraction >= 0 && minPushFraction < 1, "minPushFraction in [0,1)")
     require(dayRollDecay > 0 && dayRollDecay <= 1, "dayRollDecay in (0,1]")
     require(dayStartBlend >= 0 && dayStartBlend <= 1, "dayStartBlend in [0,1]")
   }
@@ -245,6 +252,13 @@ object CboAllocator {
       // Capacity needs evidence: enough of the day AND enough account spend.
       val capacityKnown = f >= params.minElapsedFraction &&
         spentSum >= params.minPoolSpendFraction * accountDaily
+      // Pace is judged RELATIVE to the pool: sibling campaigns share the
+      // day's traffic shape, so in a quiet hour every one of them reads
+      // under-paced on a flat clock and would be cut on nothing (#85). A
+      // campaign clearly below its siblings still reads inventory-limited.
+      val wallSum = inputs.map(_.dailyBudget).sum
+      val poolPace =
+        if (f > 0 && wallSum > 0) (spentSum / (wallSum * f)).max(MinPoolPace).min(1.0) else 1.0
 
       val prepared = inputs.map { in =>
         val post = in.prior.posterior(in.ctas, in.spent)
@@ -263,13 +277,15 @@ object CboAllocator {
           if (!capacityKnown) (Double.PositiveInfinity, false, lowerRaw, upperRaw)
           else if (!in.wallSettled) {
             // The wall moved within settleTicks: any pace reading is the echo
-            // of that move. Hold the allocation; allow a raise only when the
-            // campaign is binding against the wall it has now.
-            val hold = math.max(lowerRaw, math.min(prev, upperRaw))
-            if (paceBinding(in, f, params, tickFraction)) (Double.PositiveInfinity, false, hold, upperRaw)
-            else (Double.PositiveInfinity, false, hold, hold)
+            // of that move, so no CAPACITY cut. Rate-driven reallocation
+            // within the band stays possible (a binding sibling with a
+            // better rate may take from it), and it may be raised only when
+            // binding against the wall it has now (#85).
+            val noRaise = math.max(lowerRaw, math.min(prev, upperRaw))
+            if (paceBinding(in, f, params, tickFraction, poolPace)) (Double.PositiveInfinity, false, lowerRaw, upperRaw)
+            else (Double.PositiveInfinity, false, lowerRaw, noRaise)
           } else {
-            val cap = capacityOf(in, f, params, tickFraction)
+            val cap = capacityOf(in, f, params, tickFraction, poolPace)
             val up = math.max(lowerRaw, math.min(cap, upperRaw))
             (cap, cap < upperRaw, math.min(lowerRaw, up), up)
           }
@@ -342,29 +358,48 @@ object CboAllocator {
    * When neither binds the campaign is inventory-limited and its capacity
    * is the larger of the two projections of its own remaining-day spend.
    */
-  def capacityOf[K](in: Input[K], elapsedFraction: Double, params: Params, tickFraction: Double = 0.0): Double =
+  /** Floor on the pool pace used as the reference; below it the pool is "not spending" and pace is absolute. */
+  val MinPoolPace: Double = 0.05
+
+  /**
+   * @param poolPace the pool's own cumulative pace in (0, 1]; a campaign's cumulative pace is divided by it
+   */
+  def capacityOf[K](
+      in: Input[K],
+      elapsedFraction: Double,
+      params: Params,
+      tickFraction: Double = 0.0,
+      poolPace: Double = 1.0
+  ): Double =
     if (in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0)
       Double.PositiveInfinity
     else {
-      val (binding, cumulativeProj, instProj) = paceReadings(in, elapsedFraction, params, tickFraction)
+      val (binding, cumulativeProj, instProj) = paceReadings(in, elapsedFraction, params, tickFraction, poolPace)
       if (binding) Double.PositiveInfinity
       else math.max(cumulativeProj, instProj)
     }
 
   /** True when the campaign's spend is held back by its wall (either pace reading at or above the threshold). */
-  def paceBinding[K](in: Input[K], elapsedFraction: Double, params: Params, tickFraction: Double = 0.0): Boolean =
+  def paceBinding[K](
+      in: Input[K],
+      elapsedFraction: Double,
+      params: Params,
+      tickFraction: Double = 0.0,
+      poolPace: Double = 1.0
+  ): Boolean =
     in.exhausted || elapsedFraction < params.minElapsedFraction || in.dailyBudget <= 0.0 ||
-    paceReadings(in, elapsedFraction, params, tickFraction)._1
+    paceReadings(in, elapsedFraction, params, tickFraction, poolPace)._1
 
   /** (binding, cumulative projection, instantaneous projection) of remaining-day spend. */
   private def paceReadings[K](
       in: Input[K],
       elapsedFraction: Double,
       params: Params,
-      tickFraction: Double
+      tickFraction: Double,
+      poolPace: Double
   ): (Boolean, Double, Double) = {
     val f = elapsedFraction
-    val cumulativePace = in.spent / (in.dailyBudget * f)
+    val cumulativePace = in.spent / (in.dailyBudget * f) / poolPace.max(MinPoolPace).min(1.0)
     val cumulativeProj = math.max(0.0, in.spent / f - in.spent)
 
     val instantaneous: Option[(Double, Double)] =

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
@@ -54,6 +54,10 @@ object CboPlanner {
   /** Budget moves below this are not pushed (money is 4-decimal). */
   val PushEpsilon: Double = 1e-4
 
+  /** A move is pushed only when it is at least `minPushFraction` of the current wall (and above PushEpsilon). */
+  def material(current: Double, target: Double, params: Params): Boolean =
+    math.abs(target - current) >= math.max(PushEpsilon, params.minPushFraction * current)
+
   /** Minimum tap-throughs yesterday for the observed rate to seed the prior on its own. */
   val SeedMinCtas: Int = 5
 
@@ -127,7 +131,7 @@ object CboPlanner {
           CboAllocator.dayStartSplit(ids, pool.map(s => s.campaignId -> s.dailyBudget).toMap, accountDaily, params)
         val pushes = pool.flatMap { s =>
           val target = s.spent + split.getOrElse(s.campaignId, 0.0)
-          if (math.abs(target - s.dailyBudget) < PushEpsilon) None
+          if (!material(s.dailyBudget, target, params)) None
           else
             Some(Push(
               s.campaignId,
@@ -156,7 +160,7 @@ object CboPlanner {
         val bySnapshot = pool.map(s => s.campaignId -> s).toMap
         val pushes = alloc.results.flatMap { r =>
           val current = bySnapshot(r.id).dailyBudget
-          if (math.abs(r.newDailyBudget - current) < PushEpsilon) None
+          if (!material(current, r.newDailyBudget, params)) None
           else Some(Push(r.id, r.newDailyBudget, r.moved, r.sampledRate, r.posteriorMean))
         }
         val note = if (pushes.isEmpty) f"no move (remaining ${alloc.remaining}%.4f)" else ""

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -174,6 +174,38 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       r2.forward should be <= (1 + params.maxMovePerTick) * 30.0 + Eps
     }
 
+    "let a binding sibling with a better rate take budget from an unsettled wall (#85)" in {
+      // Both walls just moved (unsettled). a: better rate, binding. b: worse
+      // rate, not binding. Sum of walls == account remainder, so a can only
+      // rise if b may be cut. b must be cut within the band, not held.
+      val params = Params()
+      val a = Input(1, 10.0, 8L, 40.0, exhausted = true, GammaPrior(8, 10), tickSpend = Some(0.6), wallSettled = false)
+      val b =
+        Input(2, 10.0, 0L, 40.0, exhausted = false, GammaPrior(1, 100), tickSpend = Some(0.01), wallSettled = false)
+      val alloc = allocate(Vector(a, b), 80.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
+      val ra = alloc.results.find(_.id == 1).get
+      val rb = alloc.results.find(_.id == 2).get
+      ra.forward should be > 30.0
+      rb.forward should be < 30.0
+      rb.forward should be >= (1 - params.maxMovePerTick) * 30.0 - Eps
+      rb.capacity shouldBe Double.PositiveInfinity // no capacity cut while unsettled
+    }
+
+    "judge pace relative to the pool so a quiet hour cuts nobody (#85)" in {
+      val params = Params()
+      // Morning: both campaigns at 30% of flat-clock pace. Absolute pace would
+      // call both inventory-limited; relative to the pool they are on pace.
+      val a = Input(1, 1.5, 2L, 10.0, exhausted = false, GammaPrior(1, 10), tickSpend = Some(0.03))
+      val b = Input(2, 1.5, 0L, 10.0, exhausted = false, GammaPrior(1, 10), tickSpend = Some(0.03))
+      val quiet = allocate(Vector(a, b), 20.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
+      quiet.results.foreach(_.capacity shouldBe Double.PositiveInfinity)
+      // Same hour, but b is at a third of its sibling's pace: still limited.
+      val weak = allocate(Vector(a, b.copy(spent = 0.5, tickSpend = Some(0.01))), 20.0, 0.5, new Random(1), params,
+        tickFraction = 1.0 / 96)
+      weak.results.find(_.id == 2).get.capacity.isFinite shouldBe true
+      weak.results.find(_.id == 1).get.capacity shouldBe Double.PositiveInfinity
+    }
+
     "not infer capacity while the account has barely spent (quiet start)" in {
       // 1% of the account budget spent by one campaign, none by the other:
       // no campaign may be capped yet, so the zero-spend one keeps its wall

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
@@ -140,9 +140,21 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
       settled.pushes.find(_.campaignId == cb).map(_.newDailyBudget).getOrElse(41.0) should be < 41.0
       settled.capped should contain(cb)
 
+      // Pushed last tick: no capacity cut (not in the capped set), so any cut
+      // is rate-driven and stays inside the 25% band (forward 40 -> >= 30).
       val held = plan(snaps, priors, 100.0, 0.5, 1.0 / 96, last, false, new Random(1), Params(),
         tick = 10L, lastPushTick = Map(cb -> 9L))
-      held.pushes.find(_.campaignId == cb) shouldBe None
+      held.capped should not contain cb
+      held.pushes.find(_.campaignId == cb).foreach(_.newDailyBudget should be >= 1.0 + 30.0 - 1e-6)
+    }
+  }
+
+  "CboPlanner.material" should {
+    "ignore moves under 1% of the wall and keep the absolute epsilon for tiny walls (#85)" in {
+      material(10.0, 10.05, Params()) shouldBe false
+      material(10.0, 10.2, Params()) shouldBe true
+      material(0.001, 0.0012, Params()) shouldBe true
+      material(0.0, 0.00005, Params()) shouldBe false
     }
   }
 


### PR DESCRIPTION
Closes #85. Third allocator fix, from gate run 2 (#38): no blackout and no cut over 25% any more, but the split froze inverted.

## Causes

1. **Settle rule froze the allocation.** Tie-breaking moves of a few cents were pushed every tick, so every wall was "moved within settleTicks" forever. An unsettled wall could not be cut, and with the two walls summing to the account budget nothing could be raised either. The split froze wherever it stood when the sum reached the budget.
2. **Flat-clock pace misread the traffic shape.** The day-start split (about 9 / 11) was undone within a minute: at 17% of the day both campaigns read as under-paced because the scenario's early hours are quiet, and `spent / F` projected a tiny capacity for both.

## Fix

- **Material pushes only.** A move is pushed when it is at least `minPushFraction` (1%) of the wall. Walls settle; churn drops.
- **Unsettled walls block capacity cuts, not reallocation.** Rate-driven cuts within the hysteresis band stay possible, so a binding sibling with a better rate can take from an unsettled wall; the unsettled wall is raised only when binding.
- **Pool-relative pace.** Cumulative pace is divided by the pool's own pace, clamped to `[0.05, 1]`. Sibling campaigns share the day's traffic shape, so in a quiet hour every campaign reads on pace, while a campaign clearly below its siblings still reads inventory-limited.

## Tests

```
sbt "core/testOnly promovolve.advertiser.cbo.*"   # Tests: succeeded 41, failed 0
```

New: a binding sibling with a better rate takes budget from an unsettled wall, and the unsettled wall's cut stays inside the band with no capacity inferred; two campaigns at 30% of flat-clock pace in a quiet hour read on pace relative to the pool, while one at a third of its sibling's pace still reads limited; the material-push threshold. scalafmt run with a cleared cache.

## Next

Deploy, rerun the optimized scenarios (the fixed controls from gate run 2 stay valid), post on #38.

https://claude.ai/code/session_01VjNDM8pNEjbDimNF3McbZy