### PR TITLE
fix(cbo): shrink and bound cuts by lifetime evidence, not today's count

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -30,9 +30,11 @@ import scala.util.Random
  * Bounds per campaign (all on the forward allocation):
  *   - exploration floor: `explorationFloor * R / N` so a starved campaign
  *     can always prove itself (budget analogue of the newcomer boost);
- *   - hysteresis: within `[1 - maxMove, 1 + maxMove]` of the previous
+ *   - hysteresis: within `[1 - maxMove * w, 1 + maxMove]` of the previous
  *     forward allocation (`dailyBudget - spent`), so a downshift never reads
- *     as a hard over-pace to the campaign's PI controller;
+ *     as a hard over-pace to the campaign's PI controller; `w` is the
+ *     campaign's evidence weight (see `shrinkageCtas`), so a tick that
+ *     knows nothing moves nothing (#93);
  *   - capacity: a campaign whose pace is below `paceBindingThreshold` is
  *     inventory-limited, and its forward allocation is capped at its own
  *     projected remaining spend; extra budget would buy nothing.
@@ -125,12 +127,22 @@ object CboAllocator {
        */
       minPushFraction: Double = 0.01,
       /**
-       * Empirical-Bayes shrinkage toward the pool's tap-through rate: a
-       * campaign keeps `n / (n + shrinkageCtas)` of its deviation from the
-       * pool rate, where `n` is its own tap-throughs. A light value guards
-       * the first hours (the first count no longer decides the morning)
-       * without eating the gain: 3 keeps 23% of a threefold-gap gain in a
-       * two-day simulation where 20 keeps 13% (#89). 0 disables.
+       * Evidence scale, in tap-throughs. A campaign's evidence `n` is the
+       * larger of the tap-throughs its posterior has effectively seen
+       * (`alpha`, lifetime and decayed) and the number it would have
+       * expected at the pool rate over the spend it has seen, so spend
+       * without tap-throughs counts as evidence of a low rate, not as
+       * ignorance. The weight `w = n / (n + shrinkageCtas)` does two jobs:
+       *   - empirical-Bayes shrinkage: the sampled rate keeps `w` of its
+       *     deviation from the pool rate (#89);
+       *   - the cut band: a forward allocation may be cut by at most
+       *     `maxMovePerTick * w` per tick, and because the remainder is
+       *     conserved that bounds every raise too (#93).
+       * Keyed to TODAY's count this reset every morning: both rates
+       * collapsed onto the pool, the first ticks were a coin flip on 0-2
+       * tap-throughs, and the band let that flip move a fifth of the wall
+       * (#93). 3 keeps 23% of a threefold-gap gain in a two-day simulation
+       * where 20 keeps 13% (#89). 0 disables both.
        */
       shrinkageCtas: Double = 3.0,
       /**
@@ -271,28 +283,32 @@ object CboAllocator {
       // day's traffic shape, so in a quiet hour every one of them reads
       // under-paced on a flat clock and would be cut on nothing (#85). A
       // campaign clearly below its siblings still reads inventory-limited.
-      // Pool rate for shrinkage: the account's own tap-throughs per unit of
-      // spend today (None until the pool has spent anything).
-      val poolRate: Option[Double] = {
-        val ctasSum = inputs.map(_.ctas).sum.toDouble
-        if (spentSum > 0 && ctasSum > 0) Some(ctasSum / spentSum) else None
-      }
+      // Pool rate on LIFETIME evidence: the precision-weighted rate of the
+      // live posteriors, not today's counts. Today's counts reset at day
+      // roll while the posteriors carry decayed history, and a pool built
+      // from today alone made every morning a coin flip (#93).
+      val posteriors = inputs.map(in => in.prior.posterior(in.ctas, in.spent))
+      val poolRate = poolRateOf(posteriors)
       val wallSum = inputs.map(_.dailyBudget).sum
       val poolPace =
         if (f > 0 && wallSum > 0) (spentSum / (wallSum * f)).max(MinPoolPace).min(1.0) else 1.0
 
-      val prepared = inputs.map { in =>
-        val post = in.prior.posterior(in.ctas, in.spent)
-        val rate = shrinkToward(drawRate(post, rng, params), poolRate, in.ctas, params)
+      val prepared = inputs.zip(posteriors).map { case (in, post) =>
+        val evidence = evidenceOf(post, poolRate)
+        val w = evidenceWeight(evidence, params)
+        val rate = shrinkToward(drawRate(post, rng, params), Some(poolRate), evidence, params)
 
         val prev = in.previousForward
         // Hysteresis band around the previous forward allocation. Cuts and
         // raises are both bounded by the band (#82: an unbounded capacity
         // cut wound up the pacer and blacked out the campaign); a campaign
         // capped last tick probes upward by the smaller probeStep. The floor
-        // is a HARD lower bound (#38, #79).
+        // is a HARD lower bound (#38, #79). The cut side of the band scales
+        // with the campaign's evidence: a tick that knows nothing moves
+        // nothing, and since the remainder is conserved that also bounds
+        // what any sibling can be raised by (#93).
         val raiseStep = if (in.cappedLastTick) params.probeStep else params.maxMovePerTick
-        val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick) * prev)
+        val lowerRaw = math.max(floor, (1.0 - params.maxMovePerTick * w) * prev)
         val upperRaw = math.max(floor, (1.0 + raiseStep) * prev)
         val (capacity, capped, lower, upper) =
           if (!capacityKnown) (Double.PositiveInfinity, false, lowerRaw, upperRaw)
@@ -379,16 +395,35 @@ object CboAllocator {
    * When neither binds the campaign is inventory-limited and its capacity
    * is the larger of the two projections of its own remaining-day spend.
    */
+  /** Precision-weighted pool rate of the live posteriors: `sum(alpha) / sum(beta)`. */
+  def poolRateOf(posteriors: Vector[GammaPrior]): Double =
+    if (posteriors.isEmpty) MinRate else posteriors.map(_.alpha).sum / posteriors.map(_.beta).sum
+
+  /**
+   * A campaign's evidence in tap-throughs: the larger of what its posterior
+   * has effectively seen (`alpha`: prior pseudo-count plus lifetime decayed
+   * tap-throughs) and what it would have expected at the pool rate over the
+   * spend its posterior has seen (`poolRate * beta`). The second term makes
+   * spend without tap-throughs evidence of a low rate rather than an
+   * unknown, so such a campaign can still be cut (#93).
+   */
+  def evidenceOf(posterior: GammaPrior, poolRate: Double): Double =
+    math.max(posterior.alpha, poolRate * posterior.beta)
+
+  /** `n / (n + shrinkageCtas)`; 1 when shrinkage is disabled. */
+  def evidenceWeight(evidence: Double, params: Params): Double =
+    if (params.shrinkageCtas <= 0) 1.0
+    else math.max(0.0, evidence) / (math.max(0.0, evidence) + params.shrinkageCtas)
+
   /**
    * Shrink a campaign's rate toward the pool rate by its own evidence:
    * `pool + (rate - pool) * n / (n + shrinkageCtas)`. No pool rate or
    * `shrinkageCtas = 0` leaves the rate untouched.
    */
-  def shrinkToward(rate: Double, poolRate: Option[Double], ctas: Long, params: Params): Double =
+  def shrinkToward(rate: Double, poolRate: Option[Double], evidence: Double, params: Params): Double =
     poolRate match {
       case Some(p) if params.shrinkageCtas > 0 =>
-        val w = ctas.toDouble / (ctas.toDouble + params.shrinkageCtas)
-        math.max(MinRate, p + (rate - p) * w)
+        math.max(MinRate, p + (rate - p) * evidenceWeight(evidence, params))
       case _ => rate
     }
 

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -44,6 +44,13 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
   private def floorOf(remaining: Double, n: Int, params: Params): Double =
     params.explorationFloor * remaining / n
 
+  /** Each campaign's evidence weight `w` this tick, as the allocator computes it (#93). */
+  private def weightsOf(inputs: Vector[Input[Int]], params: Params): Vector[Double] = {
+    val posts = inputs.map(in => in.prior.posterior(in.ctas, in.spent))
+    val pool = poolRateOf(posts)
+    posts.map(post => evidenceWeight(evidenceOf(post, pool), params))
+  }
+
   "CboAllocator.allocate" should {
 
     "conserve the remainder and respect every per-campaign bound" in {
@@ -83,19 +90,20 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
         val n = inputs.size
         whenever(alloc.remaining > 0) {
           val floor = floorOf(alloc.remaining, n, params)
-          alloc.results.zip(inputs).foreach { case (r, in) =>
+          val weights = weightsOf(inputs, params)
+          alloc.results.zip(inputs).zip(weights).foreach { case ((r, in), w) =>
             val prev = in.previousForward
             // Upper: never more than the band above prev, unless the floor is higher.
             r.forward should be <= math.max(floor, (1 + params.maxMovePerTick) * prev) + Eps
             // Capacity caps the raise whenever it is finite, but a cut is bounded by
-            // the band (#82) and never goes below the floor.
+            // the evidence-scaled band (#82, #93) and never goes below the floor.
             if (r.capacity.isFinite)
-              r.forward should be <= math.max(math.max(r.capacity, floor), (1 - params.maxMovePerTick) * prev) + Eps
+              r.forward should be <= math.max(math.max(r.capacity, floor), (1 - params.maxMovePerTick * w) * prev) + Eps
           }
           // Lower bounds only bind when their (unscaled) sum fits into the
           // remainder; the result carries the scaled bound, so recompute.
-          val unscaledLowers = alloc.results.zip(inputs).map { case (r, in) =>
-            math.min(math.max(floor, (1 - params.maxMovePerTick) * in.previousForward), r.upper)
+          val unscaledLowers = alloc.results.zip(inputs).zip(weights).map { case ((r, in), w) =>
+            math.min(math.max(floor, (1 - params.maxMovePerTick * w) * in.previousForward), r.upper)
           }
           if (unscaledLowers.sum <= alloc.remaining + Eps) {
             alloc.results.zip(unscaledLowers).foreach { case (r, lower) =>
@@ -142,7 +150,12 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       val a1 = allocate(Vector(limited, other), 100.0, 0.5, new Random(1), params, tickFraction = 1.0 / 96)
       val r1 = a1.results.find(_.id == 1).get
       r1.capacity should be < 30.0
-      r1.forward shouldBe (1 - params.maxMovePerTick) * 40.0 +- Eps
+      // The band is scaled by the campaign's evidence weight (#93): on one
+      // tap-through it is narrower than maxMovePerTick, and the cut still
+      // stops there, far above capacity.
+      val w1 = weightsOf(Vector(limited, other), params).head
+      r1.forward shouldBe (1 - params.maxMovePerTick * w1) * 40.0 +- Eps
+      r1.forward should be > 30.0
       r1.capped shouldBe true
 
       // Same campaign, capped last tick and now pace-binding: the raise is probeStep, not maxMovePerTick.
@@ -334,6 +347,67 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
       val unshrunk = share(Params(shrinkageCtas = 0))
       shrunk should be > unshrunk
       shrunk should be >= 0.35
+    }
+  }
+
+  "CboAllocator evidence (#93)" should {
+    // Cold day-1 prior as CboPlanner.seedPrior builds it for a fresh
+    // campaign on a 10.00 account: fallback rate 1 / accountDaily at
+    // half-a-wall strength, i.e. a quarter of a pseudo tap-through.
+    val cold = GammaPrior.seed(0L, 0.0, minCtas = 5, fallbackRate = 0.1, strengthSpend = 2.5)
+
+    "barely move on a cold start with a single tap-through" in {
+      // The seed-4 scarce gate run inverted its wall at t = 15-27 s of day 1
+      // on moves of -0.80 and -1.14 (a 5.00 wall) taken on ONE tap-through.
+      val inputs = Vector(
+        Input(1, 0.3, 1L, 5.0, exhausted = false, cold),
+        Input(2, 0.3, 0L, 5.0, exhausted = false, cold)
+      )
+      val bounded = allocate(inputs, 10.0, 0.05, new Random(11), Params())
+      bounded.results.foreach { r =>
+        val prev = inputs.find(_.id == r.id).get.previousForward
+        math.abs(r.moved) should be <= 0.06 * prev
+      }
+      // Same tick with evidence weighting off: the one count moves a fifth of the wall.
+      val unbounded = allocate(inputs, 10.0, 0.05, new Random(11), Params(shrinkageCtas = 0))
+      unbounded.results.map(r => math.abs(r.moved)).max should be > 0.2 * 4.7
+    }
+
+    "carry yesterday's evidence into the morning: a threefold prior gap moves budget with no count today" in {
+      // Day 2, first tick: nothing spent or earned today, but the priors
+      // hold yesterday's 30 vs 10 tap-throughs on equal spend. Keyed to
+      // today's count the old shrinkage collapsed both onto the pool and
+      // split this evenly.
+      val strong = GammaPrior.seed(30L, 10.0, minCtas = 5, fallbackRate = 0.1, strengthSpend = 10.0)
+      val weak = GammaPrior.seed(10L, 10.0, minCtas = 5, fallbackRate = 0.1, strengthSpend = 10.0)
+      val inputs = Vector(
+        Input(1, 0.1, 0L, 5.0, exhausted = false, strong),
+        Input(2, 0.1, 0L, 5.0, exhausted = false, weak)
+      )
+      val a = allocate(inputs, 10.0, 0.02, new Random(5), Params())
+      val f = a.results.map(r => r.id -> r.forward).toMap
+      f(1) should be > 1.3 * f(2)
+    }
+
+    "treat spend without tap-throughs as evidence: a dead campaign can still be cut" in {
+      // Mid-day, both binding. A has spent 3.00 for nothing beside a
+      // sibling that earned 10 on the same spend. Evidence from spend alone
+      // (what A would have earned at the pool rate) must let the band cut
+      // it; on its own count of zero it would be frozen at its wall.
+      val inputs = Vector(
+        Input(1, 3.0, 0L, 5.0, exhausted = false, cold),
+        Input(2, 3.0, 10L, 5.0, exhausted = false, cold)
+      )
+      val a = allocate(inputs, 10.0, 0.5, new Random(2), Params())
+      val dead = a.results.find(_.id == 1).get
+      dead.forward should be < 0.9 * inputs.head.previousForward
+    }
+
+    "define evidence as the larger of seen and expected tap-throughs" in {
+      evidenceOf(GammaPrior(4.0, 2.0), poolRate = 1.0) shouldBe 4.0 +- Eps
+      evidenceOf(GammaPrior(0.25, 5.5), poolRate = 1.0) shouldBe 5.5 +- Eps
+      evidenceWeight(3.0, Params(shrinkageCtas = 3)) shouldBe 0.5 +- Eps
+      evidenceWeight(3.0, Params(shrinkageCtas = 0)) shouldBe 1.0 +- Eps
     }
   }
 


### PR DESCRIPTION
Closes #93. Found by the paired-seed gate on `554f4ffe` (#38): the scarce wall inverted — the 3×-better campaign ended with the smaller wall — in 2 of 5 runs, and every inverted run returned about 0% gain where the correct ones returned +21…+93%.

## Cause

`shrinkToward` weighted by `ctaToday / (ctaToday + shrinkageCtas)`; `ctaToday` resets at day roll while the posterior carries decayed lifetime history. Every morning both rates collapsed onto a today-only pool rate, the first ticks were a coin flip on 0–2 tap-throughs, and the ±25% band let that flip move a fifth of the wall. The trace of the inverted run shows camp1's posterior mean higher in 99% of ticks yet only 55% of moves going toward it.

## Change (allocator-local)

- **Evidence** `n = max(alpha, poolRate · beta)` of the posterior — the larger of tap-throughs effectively seen (lifetime, decayed) and those expected at the pool rate over the spend seen. Spend without tap-throughs is evidence of a low rate, not ignorance, so a dead campaign can still be cut.
- **Pool rate** `Σalpha / Σbeta` over the live posteriors, not today's counts.
- **Cut band scales with** `w = n / (n + shrinkageCtas)`. The remainder is conserved, so bounding cuts bounds raises: a tick that knows nothing moves nothing. Day 1 is a true cold start; this is what stops the morning coin flip becoming a 20% move.

## Tests

New `CboAllocator evidence (#93)` block — each from a state the allocator itself produces (#79/#82/#85 lesson):
- cold start + one tap-through: every forward moves < 6% (with weighting off, the same tick moves > 20%);
- day-2 morning, zero counts today, threefold prior gap: budget moves toward the better campaign (old shrinkage split it evenly);
- spend and no tap-throughs beside a producing sibling: the dead campaign is cut.

The band property test and the #82 capacity test now encode the scaled band. Symmetric (noiseless, 30-seed Poisson) and threefold-gap simulated-day tests pass unchanged. 47/47.

## Gate after merge

Paired seeds on a quiet host (both arms back-to-back), scarce + symmetric + ample, per the methodology in #38. Pass = scarce wall direction correct in every seed, symmetric day-3 split within 15%.

https://claude.ai/code/session_01VESW511vk3rJ5Zci7Egb7d
