### PR TITLE
feat(harness): CBO gate driver + analyzer with paired arms and validity gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ private/
 
 ### Separate repo that lives in-tree (github.com/hanishi/promovolve-book) ###
 /book/
+
+# CBO gate harness (scripts/cbo-gate.sh builds it on first use)
+scripts/runscenario.jar

--- a/docs/guides/cbo-gate.md
+++ b/docs/guides/cbo-gate.md
@@ -1,0 +1,90 @@
+# Gating Campaign Budget Optimization
+
+How to measure whether the CBO allocator (GH #38) earns more tap-throughs
+per unit of spend than fixed campaign walls, and what a result does and
+does not mean. The driver is `scripts/cbo-gate.sh`, the analyzer
+`scripts/cbo_gate_analyze.py`; the scenarios live in `scripts/scenarios/`.
+
+## The scenarios
+
+| pair | scenario | account / walls | true tap-through rates | what it tests |
+|---|---|---|---|---|
+| scarce | `cbo-two-campaign-scarce` vs `-scarce-fixed` | 10 / 5 + 5 | 0.30 vs 0.10 | walls bind; moving budget is the only lever |
+| ample | `cbo-two-campaign` vs `-fixed` | 20 / 10 + 10 | 0.30 vs 0.10 | slack exists; a wrong wall costs spend |
+| symmetric | `cbo-two-campaign-symmetric` | 10 / 5 + 5 | 0.20 vs 0.20 | the allocator must not chase noise |
+
+Three simulated days of 300 s each. The server must run with
+`SIM_DAY_DURATION_SECONDS=300 CBO_TICK_INTERVAL=3s REAUCTION_INTERVAL=30s`
+on both the api and singleton tiers.
+
+## Running it
+
+```
+kubectl --context docker-desktop -n promovolve scale deploy/promovolve-platform --replicas=0
+scripts/cbo-gate.sh --out /tmp/gate-$(date +%m%d) --seeds 4 scarce symmetric ample
+```
+
+The driver refuses to start on a loaded host (1-minute load ≥ 5), with the
+platform scaled up, or without the sim env vars; `--force` overrides. It
+builds `scripts/runscenario.jar` on first use, runs both arms of each pair
+back to back per seed, retires each run's advertiser, and prints the
+summary table at the end. Budget 16 minutes per run.
+
+## The rules, and why
+
+**Both arms per seed, back to back.** The fixed control has no allocator
+and still swings about ±12% per 1,000 spent from one run to the next
+(1802 → 2302 across one afternoon). An optimized run compared against a
+control from a different hour once produced a "failed on every criterion"
+that the paired control an hour later turned into +54%.
+
+**Judge the median over at least four valid pairs.** One 3-day run
+measures roughly 65 tap-throughs per arm; the same build produced −1.5%
+and +93% on the scarce pair under identical conditions. A single row is
+inside the noise of a ±30% criterion.
+
+**Validity is judged on the control.** The analyzer marks a pair invalid
+when the control spent under 90% of the budget-implied maximum or ran
+under 85% of the expected impressions per second. The ample scenario
+needs 20.00/day of serves to fill its budget; on a loaded host both arms
+lose a third of their impressions, the account budget is no longer below
+demand, and the scenario stops testing what it was built for — while the
+run still exits 0 with a plausible number. The optimized arm's own spend
+is informational: it under-spends by design when the strong campaign is
+capped by what it can win.
+
+**Wall direction is the primary diagnostic.** For each optimized run the
+analyzer reports whether the campaign with the higher true rate ended the
+last day holding ≥ 55% of the walls (`correct`), ≤ 45% (`INVERTED`), or
+neither. Every inverted scarce run so far returned about 0% gain and
+every correct one +21% to +93%; the direction count is far lower-variance
+than the efficiency ratio and is what actually gates the win.
+
+**Symmetric passes on day-end drift.** Its criterion is the day-3 split
+within 15% of even (drift ≤ 0.15). An every-report bar is unreachable at
+~50 tap-throughs per day for any count-driven allocator.
+
+## Reading the summary
+
+```
+seed     pair      opt/1k   ctl/1k    gain opt CTAs ctl CTAs direction    ctl spend ctl imps/s valid
+seed1    scarce      3544     1834  +93.2%      106       55 correct           100%        7.3 yes
+seed2    scarce      2676     1880  +42.4%       80       55 correct            99%        7.3 yes
+seed3    ample       1939     2518  -23.0%       78      113 unseparated        75%        9.7 NO
+
+scarce: 2 valid pair(s); gain median +67.8%, range +42.4% .. +93.2%; direction correct 2, inverted 0, unseparated 0
+ample: no valid pairs
+```
+
+Pass for a build: scarce direction correct in every valid seed, symmetric
+drift ≤ 0.15 at day end, and the scarce gain median ≥ +30%. Ample only
+counts on a quiet host.
+
+## Reading one log
+
+`scripts/cbo_gate_analyze.py DIR/seed1/cbo-two-campaign-scarce.log` prints
+the per-tick table (server-side wall, impressions, tap-throughs, spend per
+campaign), the day-by-day tap-throughs per 1,000 with day-end walls, and
+the validity and direction lines. The allocator's own reasoning is in the
+singleton pod's log when `LOG_CLASS=promovolve.advertiser.AdvertiserEntity`
+is set — read it *during* the run, pod logs rotate within minutes.

--- a/scripts/cbo-gate.sh
+++ b/scripts/cbo-gate.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# CBO gate: paired-seed runs of the cbo-two-campaign scenarios against the
+# docker-desktop dev cluster (GH #38, #95).
+#
+# Usage:
+#   scripts/cbo-gate.sh --out DIR [--seeds N] [--force] PAIR...
+#
+#   PAIR is one of: scarce   (cbo-two-campaign-scarce + -scarce-fixed)
+#                   ample    (cbo-two-campaign + -fixed)
+#                   symmetric (cbo-two-campaign-symmetric; no control)
+#
+#   scripts/cbo-gate.sh --out /tmp/gate --seeds 4 scarce symmetric
+#
+# Every seed runs BOTH arms of a pair back to back: the fixed control swings
+# about +-12% run to run, so an optimized number is only meaningful against a
+# control drawn from the same conditions. One run is inside the noise of the
+# +-30% criterion; judge the summary's median over >= 4 valid pairs.
+#
+# Refuses to start (override with --force) when:
+#   - host 1-minute load >= 5: the ample scenario is throughput-bound and a
+#     loaded host silently starves BOTH arms (exit 0, plausible numbers);
+#   - the platform deployment is scaled above 0: its wallet sweep (:09/:39)
+#     suspends harness advertisers mid-run;
+#   - the api statefulset lacks SIM_DAY_DURATION_SECONDS / CBO_TICK_INTERVAL.
+#
+# Server-side env for a 300 s day (set on api AND singleton):
+#   SIM_DAY_DURATION_SECONDS=300 CBO_TICK_INTERVAL=3s REAUCTION_INTERVAL=30s
+#   LOG_CLASS=promovolve.advertiser.AdvertiserEntity   (allocator trace)
+#
+# Harness: RunScenario packaged as a jar (scala-cli's resident compiler got
+# a 12-run chain OOM-killed; the jar with -Xmx512m did not). Built on first
+# use into scripts/runscenario.jar (gitignored):
+#   scala-cli --power package scripts/RunScenario.scala -o scripts/runscenario.jar
+#
+# Each run's advertiser is retired at the end (daily budget 0, manual mode):
+# harness advertisers share additionalCategories 653/654/655 and a live one
+# from an earlier run takes impressions from the next.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+CTX="${KUBE_CONTEXT:-docker-desktop}"
+NS="${KUBE_NAMESPACE:-promovolve}"
+API="${API:-http://localhost:8080}"
+JAR="${JAR:-$HERE/runscenario.jar}"
+OUT=""
+SEEDS=1
+FORCE=0
+PAIRS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --out) OUT="$2"; shift 2 ;;
+    --seeds) SEEDS="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    --context) CTX="$2"; shift 2 ;;
+    --namespace) NS="$2"; shift 2 ;;
+    -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    scarce|ample|symmetric) PAIRS+=("$1"); shift ;;
+    *) echo "Unknown: $1" >&2; exit 1 ;;
+  esac
+done
+[[ -n "$OUT" && ${#PAIRS[@]} -gt 0 ]] || { echo "need --out DIR and at least one PAIR (scarce|ample|symmetric)" >&2; exit 1; }
+
+kc() { kubectl --context "$CTX" -n "$NS" "$@"; }
+refuse() { echo "REFUSING: $*" >&2; [[ $FORCE -eq 1 ]] && { echo "  (--force given, continuing)" >&2; return 0; }; exit 2; }
+
+# ---- preflight ---------------------------------------------------------------
+load1=$(uptime | sed -E 's/.*load average[s]?: *//' | tr -d ',' | awk '{print $1}')
+if awk -v l="$load1" 'BEGIN{exit !(l >= 5)}'; then
+  refuse "host load $load1 >= 5. Close IDEs and wait; the ample scenario starves silently on a loaded host."
+fi
+
+replicas=$(kc get deploy promovolve-platform -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "?")
+if [[ "$replicas" != "0" ]]; then
+  refuse "platform deployment has $replicas replica(s); its wallet sweep suspends harness advertisers. Run: kubectl --context $CTX -n $NS scale deploy/promovolve-platform --replicas=0"
+fi
+
+envs=$(kc get statefulset promovolve-api -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value} {end}' 2>/dev/null || true)
+for v in SIM_DAY_DURATION_SECONDS CBO_TICK_INTERVAL; do
+  echo "$envs" | grep -q "$v=" || refuse "api statefulset lacks $v (set it on api AND singleton; see the header)"
+done
+
+if [[ ! -f "$JAR" ]]; then
+  command -v scala-cli >/dev/null || { echo "no $JAR and no scala-cli to build it" >&2; exit 1; }
+  echo "building $JAR ..."
+  scala-cli --power package "$HERE/RunScenario.scala" -o "$JAR" -f
+fi
+command -v java >/dev/null || { echo "java not found" >&2; exit 1; }
+command -v node >/dev/null || { echo "node not found (used to retire advertisers)" >&2; exit 1; }
+mkdir -p "$OUT"
+
+echo "gate: pairs=${PAIRS[*]} seeds=$SEEDS out=$OUT load=$load1 api digest=$(kc get statefulset promovolve-api -o jsonpath='{.spec.template.spec.containers[0].image}' | sed 's/.*@sha256://' | cut -c1-12)"
+
+# ---- helpers -----------------------------------------------------------------
+settle() {
+  # Wait until the api pod is ready and has been quiet for a moment.
+  local i n ready
+  for i in $(seq 1 16); do
+    n=$(kc logs promovolve-api-0 --since=45s 2>/dev/null | grep -c "Connection is not available\|Exception during recovery" || true)
+    ready=$(kc get pod promovolve-api-0 -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo false)
+    if [[ "$n" == "0" && $i -gt 2 && "$ready" == "true" ]]; then break; fi
+    sleep 30
+  done
+  echo "  settled after ~$((i*30))s"
+}
+
+retire() {
+  # Zero the run's advertiser so it cannot bid against the next run.
+  local log="$1" adv
+  adv=$(grep -o "adv-1-[0-9-]*" "$log" | head -1 || true)
+  [[ -n "$adv" ]] || { echo "  (no advertiser id in $log)"; return 0; }
+  node -e "
+    const a='$adv', api='$API';
+    fetch(api+'/v1/advertisers/'+a).then(r=>r.json()).then(j=>console.log('  advertiser '+a+' status at end:', j.status)).catch(()=>{});
+    fetch(api+'/v1/advertisers/'+a+'/budget',{method:'PUT',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({dailyBudget:'0',budgetMode:'manual'})}).then(r=>console.log('  retired '+a+' ('+r.status+')')).catch(e=>console.log('  retire failed', e.message));
+  "
+}
+
+run_one() {
+  local dir="$1" sc="$2" log="$dir/$sc.log"
+  echo "=== $sc start $(date +%H:%M:%S) ==="
+  settle
+  java -Xmx512m -jar "$JAR" --scenario "$ROOT/scripts/scenarios/$sc.json" > "$log" 2>&1 || echo "  exit=$? (see $log)"
+  echo "=== $sc exit $(date +%H:%M:%S) ==="
+  grep -n "STOPPING\|Exception in\|ERROR" "$log" | tail -2 || true
+  retire "$log"
+  python3 "$HERE/cbo_gate_analyze.py" "$log" | tail -8
+}
+
+# ---- run ---------------------------------------------------------------------
+for s in $(seq 1 "$SEEDS"); do
+  dir="$OUT/seed$s"
+  mkdir -p "$dir"
+  for p in "${PAIRS[@]}"; do
+    case $p in
+      scarce)    run_one "$dir" cbo-two-campaign-scarce; run_one "$dir" cbo-two-campaign-scarce-fixed ;;
+      ample)     run_one "$dir" cbo-two-campaign;        run_one "$dir" cbo-two-campaign-fixed ;;
+      symmetric) run_one "$dir" cbo-two-campaign-symmetric ;;
+    esac
+  done
+  echo "--- seed $s complete $(date +%H:%M:%S)"
+done
+
+echo
+echo "=== SUMMARY ($OUT) ==="
+python3 "$HERE/cbo_gate_analyze.py" --summary "$OUT"

--- a/scripts/cbo_gate_analyze.py
+++ b/scripts/cbo_gate_analyze.py
@@ -232,7 +232,9 @@ def verdict(o):
         ok = sf >= CONTROL_SPEND_MIN and (rf is None or rf >= CONTROL_THROUGHPUT_MIN)
         print(f"           {'VALID' if ok else 'INVALID'} "
               f"(needs spend >= {CONTROL_SPEND_MIN:.0%}, throughput >= {CONTROL_THROUGHPUT_MIN:.0%})")
-    if o["symmetric"] and o["walls"]:
+    if o["optimized"] is False and not o["symmetric"]:
+        print("direction: n/a (fixed walls)")
+    elif o["symmetric"] and o["walls"]:
         ids = sorted(o["walls"])
         tot = sum(o["walls"].values())
         sh = o["walls"][ids[0]] / tot if tot > 0 else 0.5

--- a/scripts/cbo_gate_analyze.py
+++ b/scripts/cbo_gate_analyze.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Analyze CBO gate logs: RunScenario output for the cbo-two-campaign* scenarios (GH #38, #95).
+
+Single log
+    scripts/cbo_gate_analyze.py LOG [--scenario scripts/scenarios/NAME.json]
+
+    Per-tick table, day-by-day tap-throughs per 1,000 spent, day-end walls,
+    then a verdict block: spend against the budget-implied maximum,
+    throughput against the scenario's expectation, and whether the campaign
+    with the higher true tap-through rate ended the last day with the larger
+    wall (the wall-direction diagnostic).
+
+Summary over a gate run
+    scripts/cbo_gate_analyze.py --summary DIR
+
+    DIR holds seed*/ subdirectories written by scripts/cbo-gate.sh. Pairs each
+    optimized log with its back-to-back control, applies the validity gate,
+    and prints the per-seed table with median and range of the gain.
+
+Rules encoded here (why: #38 comment on gate runs 5-7):
+  * A pair is VALID only if its CONTROL spent >= 90% of the budget-implied
+    maximum and ran at >= 85% of the expected impressions/sec. The fixed
+    control has no allocator, so under-spend there is the environment (a
+    loaded host starves the throughput-bound ample scenario). The optimized
+    arm under-spends by design when the strong campaign is capped by what it
+    can win, so its own spend is informational.
+  * Symmetric has no control: it is budget-capped like scarce, so its own
+    spend judges validity and its metric is drift from an even split.
+  * Wall direction: the higher-true-rate campaign (max ctaRates) must end the
+    last day with >= 55% of the forward budget. <= 45% is INVERTED.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import statistics
+import sys
+
+REPORT = re.compile(r"─── Report @ (\d+) requests \(([\d.]+)s elapsed\)")
+ROLL = re.compile(r"DAY ROLLOVER: Completed simulated day (\d+)")
+CAMP = re.compile(
+    r"^\s+(\S+)\s+(01[0-9A-Z]{24})\s+budget=\$([\d.]+)\s+(\d+) imps\s+(\d+) clicks\s+(\d+) tap-throughs\s+spend=\$([\d.]+)"
+)
+CAMP_LEGACY = re.compile(
+    r"^\s+(\S+)\s+budget=\$([\d.]+)\s+(\d+) imps\s+(\d+) clicks\s+(\d+) tap-throughs\s+spend=\$([\d.]+)"
+)
+TOTAL = re.compile(r"Tap-through:\s+(\d+) \(([\d.]+)% of clicks, ([\d.]+) per 1,000 spent\)")
+IMPS = re.compile(r"Impressions:\s+(\d+)\s+\(avg: ([\d.]+)/sec")
+STOP = re.compile(r"STOPPING: Reached (\d+) simulated days")
+
+SCENARIO_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scenarios")
+
+CONTROL_SPEND_MIN = 0.90
+CONTROL_THROUGHPUT_MIN = 0.85
+DIRECTION_MARGIN = 0.55
+
+
+def parse(path):
+    """Reports as dicts: elapsed, day, camps {id: (budget, imps, clicks, ctas, spend)}, total."""
+    reports, day, cur = [], 1, None
+    imps, rate, stopped_days = 0, 0.0, None
+    for line in open(path, encoding="utf-8", errors="replace"):
+        m = ROLL.search(line)
+        if m:
+            day = int(m.group(1)) + 1
+            continue
+        m = STOP.search(line)
+        if m:
+            stopped_days = int(m.group(1))
+            continue
+        m = REPORT.search(line)
+        if m:
+            cur = {"elapsed": float(m.group(2)), "day": day, "camps": {}, "total": None}
+            reports.append(cur)
+            continue
+        if cur is None:
+            continue
+        m = TOTAL.search(line)
+        if m:
+            cur["total"] = (int(m.group(1)), float(m.group(3)))
+            continue
+        m = IMPS.search(line)
+        if m:
+            imps, rate = int(m.group(1)), float(m.group(2))
+            continue
+        m = CAMP.match(line)
+        if m:
+            cur["camps"][m.group(2)] = (
+                float(m.group(3)), int(m.group(4)), int(m.group(5)), int(m.group(6)), float(m.group(7))
+            )
+            continue
+        m = CAMP_LEGACY.match(line)
+        if m:
+            cur["camps"][m.group(1)] = (
+                float(m.group(2)), int(m.group(3)), int(m.group(4)), int(m.group(5)), float(m.group(6))
+            )
+    return {"reports": reports, "imps": imps, "rate": rate, "days": stopped_days}
+
+
+def load_scenario(log_path, explicit):
+    """The scenario JSON: explicit path, else scripts/scenarios/<log basename>.json."""
+    path = explicit
+    if not path:
+        cand = os.path.join(SCENARIO_DIR, os.path.splitext(os.path.basename(log_path))[0] + ".json")
+        if os.path.exists(cand):
+            path = cand
+    if not path:
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def expectations(sc):
+    """(account daily budget, days, expected imps/sec, better campaign index or None, optimized?)."""
+    if not sc:
+        return None
+    setup, traffic, pacing = sc.get("setup", {}), sc.get("traffic", {}), sc.get("pacing", {})
+    account = float(setup.get("advertiserBudget", 0.0))
+    days = int(traffic.get("stopAfterDays", 0))
+    cpm = float(setup.get("cpm", 0.0))
+    day_len = float(pacing.get("dayDurationSeconds", 0.0))
+    per_sec = (account / cpm * 1000.0 / day_len) if cpm > 0 and day_len > 0 else 0.0
+    rates = setup.get("ctaRates") or []
+    better = None
+    if rates and max(rates) > min(rates):
+        better = rates.index(max(rates))
+    optimized = setup.get("budgetMode") == "optimized"
+    return {"account": account, "days": days, "per_sec": per_sec, "better": better, "optimized": optimized,
+            "symmetric": bool(rates) and better is None}
+
+
+def day_rows(reports):
+    """Last report of each day -> (day, ctas delta, spend delta, per1k, walls dict, forward shares dict)."""
+    last_by_day = {}
+    for r in reports:
+        last_by_day[r["day"]] = r
+    rows, prev = [], (0, 0.0)
+    for d in sorted(last_by_day):
+        r = last_by_day[d]
+        ctas = sum(v[3] for v in r["camps"].values())
+        spend = sum(v[4] for v in r["camps"].values())
+        dc, ds = ctas - prev[0], spend - prev[1]
+        per1k = dc / ds * 1000 if ds > 0 else 0.0
+        walls = {c: r["camps"][c][0] for c in r["camps"]}
+        fwd = {c: max(0.0, r["camps"][c][0] - r["camps"][c][4]) for c in r["camps"]}
+        ftot = sum(fwd.values())
+        shares = {c: (fwd[c] / ftot if ftot > 0 else None) for c in fwd}
+        rows.append((d, dc, ds, per1k, walls, shares, ctas, spend))
+        prev = (ctas, spend)
+    return rows
+
+
+def direction(rows, days, better):
+    """('correct'|'INVERTED'|'unseparated'|'n/a', better share) from the last complete day's walls."""
+    complete = [r for r in rows if r[0] <= (days or r[0])]
+    if better is None or not complete:
+        return "n/a", None
+    walls = complete[-1][4]
+    ids = sorted(walls)  # ULIDs are time-ordered: creation order = scenario campaign index
+    if len(ids) < 2 or better >= len(ids):
+        return "n/a", None
+    total = sum(walls.values())
+    share = walls[ids[better]] / total if total > 0 else 0.5
+    if share >= DIRECTION_MARGIN:
+        return "correct", share
+    if share <= 1 - DIRECTION_MARGIN:
+        return "INVERTED", share
+    return "unseparated", share
+
+
+def analyze(log_path, scenario_path=None, quiet=False):
+    p = parse(log_path)
+    reports = p["reports"]
+    if not reports:
+        if not quiet:
+            print(f"{log_path}: no reports found")
+        return None
+    sc = expectations(load_scenario(log_path, scenario_path))
+    names = sorted({c for r in reports for c in r["camps"]})
+    rows = day_rows(reports)
+    days = p["days"] or (sc["days"] if sc else None)
+    complete = [r for r in rows if days is None or r[0] <= days]
+    total_ctas = complete[-1][6] if complete else 0
+    total_spend = complete[-1][7] if complete else 0.0
+    per1k = total_ctas / total_spend * 1000 if total_spend > 0 else 0.0
+    dirn, share = direction(rows, days, sc["better"] if sc else None)
+    out = {
+        "log": log_path, "ctas": total_ctas, "spend": total_spend, "per1k": per1k,
+        "imps": p["imps"], "rate": p["rate"], "direction": dirn, "better_share": share,
+        "walls": complete[-1][4] if complete else {}, "days": days,
+        "optimized": sc["optimized"] if sc else None, "symmetric": sc["symmetric"] if sc else False,
+    }
+    if sc and sc["account"] > 0 and days:
+        out["spend_fraction"] = total_spend / (sc["account"] * days)
+    if sc and sc["per_sec"] > 0:
+        out["rate_fraction"] = p["rate"] / sc["per_sec"]
+        out["expected_rate"] = sc["per_sec"]
+    if quiet:
+        return out
+
+    print(f"{'elapsed':>8} {'day':>3} " + " ".join(f"{n[-8:]:>30}" for n in names))
+    print(f"{'':>8} {'':>3} " + " ".join(f"{'budget  imps  ctas  spend':>30}" for _ in names))
+    for r in reports:
+        cells = []
+        for n in names:
+            b, imps, clicks, ctas, spend = r["camps"].get(n, (0, 0, 0, 0, 0.0))
+            cells.append(f"{b:8.2f} {imps:5d} {ctas:5d} {spend:8.2f}")
+        print(f"{r['elapsed']:8.0f} {r['day']:>3} " + " ".join(f"{c:>30}" for c in cells))
+    print()
+    print(f"{'day':>3} {'ctas':>6} {'spend':>8} {'ctas/1000':>10}   walls at day end (creation order)")
+    for d, dc, ds, rate, walls, shares, _, _ in rows:
+        w = "  ".join(f"{walls[c]:.2f}" for c in sorted(walls))
+        print(f"{d:>3} {dc:6d} {ds:8.2f} {rate:10.2f}   {w}")
+    print()
+    print(f"final: {total_ctas} tap-throughs, {total_spend:.2f} spent, {per1k:.2f} per 1,000 (days 1-{days})")
+    verdict(out)
+    return out
+
+
+def verdict(o):
+    """The validity and direction lines for one log."""
+    sf = o.get("spend_fraction")
+    rf = o.get("rate_fraction")
+    spend_s = f"spend {sf:.0%} of budget-implied" if sf is not None else "spend fraction unknown (no scenario)"
+    rate_s = (f"throughput {o['rate']:.1f}/s = {rf:.0%} of expected {o['expected_rate']:.1f}/s"
+              if rf is not None else f"throughput {o['rate']:.1f}/s")
+    print(f"validity:  {spend_s}; {rate_s}")
+    if o["optimized"] and not o["symmetric"]:
+        print("           optimized arm: judged by its paired control (it under-spends by design when capped)")
+    elif sf is not None:
+        ok = sf >= CONTROL_SPEND_MIN and (rf is None or rf >= CONTROL_THROUGHPUT_MIN)
+        print(f"           {'VALID' if ok else 'INVALID'} "
+              f"(needs spend >= {CONTROL_SPEND_MIN:.0%}, throughput >= {CONTROL_THROUGHPUT_MIN:.0%})")
+    if o["symmetric"] and o["walls"]:
+        ids = sorted(o["walls"])
+        tot = sum(o["walls"].values())
+        sh = o["walls"][ids[0]] / tot if tot > 0 else 0.5
+        print(f"direction: symmetric, camp1 share {sh:.3f} (drift {abs(sh - 0.5):.3f}; bar 0.15 at day end)")
+    elif o["direction"] != "n/a":
+        print(f"direction: {o['direction']} (better campaign holds {o['better_share']:.2f} of the walls; "
+              f">= {DIRECTION_MARGIN:.2f} correct, <= {1 - DIRECTION_MARGIN:.2f} inverted)")
+
+
+PAIRS = [
+    ("scarce", "cbo-two-campaign-scarce", "cbo-two-campaign-scarce-fixed"),
+    ("ample", "cbo-two-campaign", "cbo-two-campaign-fixed"),
+]
+SYMMETRIC = "cbo-two-campaign-symmetric"
+
+
+def control_valid(c):
+    sf, rf = c.get("spend_fraction"), c.get("rate_fraction")
+    if sf is None:
+        return None
+    return sf >= CONTROL_SPEND_MIN and (rf is None or rf >= CONTROL_THROUGHPUT_MIN)
+
+
+def summary(root):
+    dirs = sorted(glob.glob(os.path.join(root, "seed*")))
+    if os.path.exists(os.path.join(root, "cbo-two-campaign-scarce.log")) or \
+            os.path.exists(os.path.join(root, "cbo-two-campaign.log")):
+        dirs.insert(0, root)
+    if not dirs:
+        print(f"no seed*/ directories under {root}")
+        return 1
+    print(f"{'seed':<8} {'pair':<7} {'opt/1k':>8} {'ctl/1k':>8} {'gain':>7} {'opt CTAs':>8} {'ctl CTAs':>8} "
+          f"{'direction':<12} {'ctl spend':>9} {'ctl imps/s':>10} valid")
+    gains = {"scarce": [], "ample": []}
+    dirs_ok = {"scarce": [0, 0, 0], "ample": [0, 0, 0]}  # correct, inverted, unseparated (valid pairs only)
+    sym = []
+    for d in dirs:
+        seed = os.path.basename(d.rstrip("/")) if d != root else "-"
+        for pair, opt_name, ctl_name in PAIRS:
+            ol, cl = os.path.join(d, opt_name + ".log"), os.path.join(d, ctl_name + ".log")
+            if not (os.path.exists(ol) and os.path.exists(cl)):
+                continue
+            o, c = analyze(ol, quiet=True), analyze(cl, quiet=True)
+            if not o or not c:
+                continue
+            valid = control_valid(c)
+            gain = (o["per1k"] / c["per1k"] - 1) if c["per1k"] > 0 else float("nan")
+            sf = c.get("spend_fraction")
+            sf_s = f"{sf:.0%}" if sf is not None else "?"
+            valid_s = "yes" if valid else ("?" if valid is None else "NO")
+            print(f"{seed:<8} {pair:<7} {o['per1k']:8.0f} {c['per1k']:8.0f} {gain:+7.1%} {o['ctas']:8d} {c['ctas']:8d} "
+                  f"{o['direction']:<12} {sf_s:>9} {c['rate']:10.1f} {valid_s}")
+            if valid:
+                gains[pair].append(gain)
+                idx = {"correct": 0, "INVERTED": 1}.get(o["direction"], 2)
+                dirs_ok[pair][idx] += 1
+        sl = os.path.join(d, SYMMETRIC + ".log")
+        if os.path.exists(sl):
+            s = analyze(sl, quiet=True)
+            if s and s["walls"]:
+                ids = sorted(s["walls"])
+                tot = sum(s["walls"].values())
+                sh = s["walls"][ids[0]] / tot if tot > 0 else 0.5
+                ok = control_valid(s)
+                sym.append((seed, sh, ok))
+                drift = f"drift {abs(sh - 0.5):.3f}"
+                sf = s.get("spend_fraction")
+                sf_s = f"{sf:.0%}" if sf is not None else "?"
+                valid_s = "yes" if ok else ("?" if ok is None else "NO")
+                print(f"{seed:<8} {'sym':<7} {'':>8} {'':>8} {'':>7} {s['ctas']:8d} {'':>8} "
+                      f"{drift:<12} {sf_s:>9} {s['rate']:10.1f} {valid_s}")
+    print()
+    for pair in ("scarce", "ample"):
+        g = [x for x in gains[pair] if x == x]
+        if g:
+            c, i, u = dirs_ok[pair]
+            print(f"{pair}: {len(g)} valid pair(s); gain median {statistics.median(g):+.1%}, "
+                  f"range {min(g):+.1%} .. {max(g):+.1%}; direction correct {c}, inverted {i}, unseparated {u}")
+        else:
+            print(f"{pair}: no valid pairs")
+    if sym:
+        drifts = [abs(sh - 0.5) for _, sh, ok in sym if ok]
+        if drifts:
+            print(f"symmetric: {len(drifts)} valid run(s); day-end drift median {statistics.median(drifts):.3f}, "
+                  f"max {max(drifts):.3f} (bar 0.15)")
+    print()
+    print("read: a single pair is inside the noise of a +-30% criterion (~65 tap-throughs per arm, controls swing "
+          "+-12%). Judge the median over >= 4 valid pairs and the direction count, not one row.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("log", nargs="?", help="one RunScenario log")
+    ap.add_argument("--scenario", help="scenario JSON (default: scripts/scenarios/<log basename>.json)")
+    ap.add_argument("--summary", metavar="DIR", help="summarize a gate run directory (seed*/ subdirs)")
+    a = ap.parse_args()
+    if a.summary:
+        sys.exit(summary(a.summary))
+    if not a.log:
+        ap.error("LOG or --summary DIR required")
+    sys.exit(0 if analyze(a.log, a.scenario) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #95. Promotes the CBO gate out of a session scratchpad into `scripts/`, with the rules from the 2026-09-08 gate runs (#38) enforced rather than remembered.

## `scripts/cbo-gate.sh`

- `--out DIR --seeds N PAIR...` with PAIR = `scarce` | `ample` | `symmetric`; both arms of a pair run **back to back per seed**, each seed in its own directory.
- Refuses (override `--force`) on host 1-minute load ≥ 5, platform scaled above 0, or missing `SIM_DAY_DURATION_SECONDS` / `CBO_TICK_INTERVAL` on the api statefulset.
- Builds `scripts/runscenario.jar` on first use (gitignored), retires each run's advertiser, prints the summary at the end.

## `scripts/cbo_gate_analyze.py`

- Per log: per-tick table, day rows with day-end walls, spend vs budget-implied maximum, throughput vs the scenario's expectation, and the **wall-direction verdict** (higher-true-rate campaign holds ≥ 55% of the walls = correct, ≤ 45% = INVERTED).
- `--summary DIR`: pairs each optimized log with its control; a pair is **valid only if the control** spent ≥ 90% of budget-implied and ran ≥ 85% of expected imps/s — the control has no allocator, so under-spend there is the environment, while the optimized arm under-spends by design when capped. Prints median and range of the gain and the direction count.

## `docs/guides/cbo-gate.md`

The procedure and why each rule exists.

## Applied to today's runs (`554f4ffe`)

```
seed     pair      opt/1k   ctl/1k    gain opt CTAs ctl CTAs direction    ctl spend ctl imps/s valid
-        scarce      3544     1808  +96.0%      106       54 correct           100%        7.3 yes
seed2    scarce      2676     1825  +46.7%       80       51 unseparated        93%        7.3 yes
seed2    ample       3088     2035  +51.8%      131      102 correct            84%       12.2 NO
seed3    scarce      2382     1968  +21.0%       71       59 correct           100%        7.3 yes
seed3    ample       2001     2487  -19.6%       77      111 correct            74%       10.7 NO
seed4    scarce      2200     2302   -4.4%       63       69 INVERTED          100%        7.5 yes
seed4    ample       2517     1427  +76.4%       98       36 correct            42%        6.4 NO

scarce: 4 valid pair(s); gain median +33.9%, range -4.4% .. +96.0%; direction correct 2, inverted 1, unseparated 1
ample: no valid pairs
```

The driver's run loop is the same settle → run → retire → analyze sequence that produced those logs; the preflight was exercised on the loaded host (it refuses at load 15). No allocator or scenario changes.

https://claude.ai/code/session_01VESW511vk3rJ5Zci7Egb7d
