### PR TITLE
fix(cbo): reserve live fixed siblings' walls off the allocator's budget

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
@@ -115,20 +115,34 @@ object CboPlanner {
       cappedLast: Set[CampaignId] = Set.empty
   ): Plan = {
     val pool = eligible(snapshots)
+    // Live fixed-strategy siblings keep their own walls, so their walls are
+    // reserved off the account budget and the allocator pools what is left.
+    // Handed the whole account budget it over-promised the auto campaigns:
+    // fixed siblings spent the same money first-come-first-served and the
+    // auto walls were then stopped by the account cap, not by the split (#99).
+    val reservedFixed = snapshots.filter(s => s.live && s.strategy != CboStrategy.Auto).map(_.dailyBudget).sum
+    val poolBudget = math.max(0.0, accountDaily - reservedFixed)
     if (pool.size < MinCampaigns)
       Plan(Vector.empty, priors, dayStartApplied = false, s"${pool.size} live auto campaign(s), need $MinCampaigns")
     else if (accountDaily <= 0.0)
       Plan(Vector.empty, priors, dayStartApplied = false, "account daily budget is zero")
+    else if (poolBudget <= 0.0)
+      Plan(
+        Vector.empty,
+        priors,
+        dayStartApplied = false,
+        f"fixed walls ($reservedFixed%.4f) reach the account budget ($accountDaily%.4f); nothing to allocate"
+      )
     else {
       // Seed priors for campaigns joining the pool; known ones are untouched.
       val seeded = pool.foldLeft(priors) { (acc, s) =>
-        if (acc.contains(s.campaignId)) acc else acc.updated(s.campaignId, seedPrior(s, acc, accountDaily))
+        if (acc.contains(s.campaignId)) acc else acc.updated(s.campaignId, seedPrior(s, acc, poolBudget))
       }
 
       if (dayStartPending) {
         val ids = pool.map(_.campaignId)
         val split =
-          CboAllocator.dayStartSplit(ids, pool.map(s => s.campaignId -> s.dailyBudget).toMap, accountDaily, params)
+          CboAllocator.dayStartSplit(ids, pool.map(s => s.campaignId -> s.dailyBudget).toMap, poolBudget, params)
         val pushes = pool.flatMap { s =>
           val target = s.spent + split.getOrElse(s.campaignId, 0.0)
           if (!material(s.dailyBudget, target, params)) None
@@ -156,7 +170,7 @@ object CboPlanner {
             wallSettled = lastPushTick.get(s.campaignId).forall(t => tick - t >= params.settleTicks)
           )
         }
-        val alloc = CboAllocator.allocate(inputs, accountDaily, elapsedFraction, rng, params, tickFraction)
+        val alloc = CboAllocator.allocate(inputs, poolBudget, elapsedFraction, rng, params, tickFraction)
         val bySnapshot = pool.map(s => s.campaignId -> s).toMap
         val pushes = alloc.results.flatMap { r =>
           val current = bySnapshot(r.id).dailyBudget

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
@@ -133,6 +133,40 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "CboPlanner.plan with fixed siblings (#99)" should {
+    // Sum of the pool's daily budgets after the plan: pushed values where
+    // pushed, current walls otherwise.
+    def wallsAfter(p: Plan, snaps: Vector[Snapshot]): Double =
+      snaps.filter(_.strategy == CboStrategy.Auto).map { s =>
+        p.pushes.find(_.campaignId == s.campaignId).map(_.newDailyBudget).getOrElse(s.dailyBudget)
+      }.sum
+
+    "reserve a live fixed sibling's wall off the pool budget" in {
+      // Two auto campaigns holding 50 + 50 beside a fixed one on 40, account
+      // 100: the pool has 60, not 100. The auto walls exceed it, so the
+      // plan scales them down to spent + 40 of forward = 60 in total.
+      val auto = Vector(snap(ca, 50, 10, 1), snap(cb, 50, 10, 1))
+      val mixed = auto :+ snap(cc, 40, 5, 1, strategy = CboStrategy.Fixed)
+      wallsAfter(run(mixed), mixed) shouldBe 60.0 +- 1e-3
+      // Without the fixed sibling the same pool keeps the whole account budget.
+      wallsAfter(run(auto), auto) shouldBe 100.0 +- 1e-3
+    }
+
+    "reserve nothing for a fixed campaign that is not live" in {
+      val snaps = Vector(snap(ca, 50, 10, 1), snap(cb, 50, 10, 1),
+        snap(cc, 40, 0, 0, strategy = CboStrategy.Fixed, live = false))
+      wallsAfter(run(snaps), snaps) shouldBe 100.0 +- 1e-3
+    }
+
+    "push nothing and say so when fixed walls reach the account budget" in {
+      val snaps = Vector(snap(ca, 50, 10, 1), snap(cb, 50, 10, 1), snap(cc, 100, 5, 1, strategy = CboStrategy.Fixed))
+      val p = run(snaps)
+      p.pushes shouldBe empty
+      p.dayStartApplied shouldBe false
+      p.note should include("nothing to allocate")
+    }
+  }
+
   "CboPlanner.plan with wall memory (#82)" should {
     "hold a campaign whose wall was pushed within settleTicks and report capped campaigns" in {
       // b is inventory-limited (1 of 40 spent at mid-day) and would be cut when settled.

--- a/platform/internal/i18n/ja.go
+++ b/platform/internal/i18n/ja.go
@@ -487,7 +487,7 @@ var ja = map[string]string{
 	"Budget mode":          "予算モード",
 	"Manual":               "手動",
 	"Optimized":            "最適化",
-	"Manual: every campaign keeps its own daily budget and the account budget is a hard cap. Optimized: the account budget is re-split every few minutes across the campaigns whose budget strategy is Optimized, toward the ones earning the most tap-throughs per unit of spend. It needs at least two such campaigns; below that it does nothing.": "手動：各キャンペーンが自分の日予算を持ち、アカウント予算は上限として働きます。最適化：予算戦略が「最適化」のキャンペーン間で、支出あたりのタップスルーが多いものへアカウント予算を数分ごとに再配分します。対象キャンペーンが2件以上必要で、それ未満では何もしません。",
+	"Manual: every campaign keeps its own daily budget and the account budget is a hard cap on all of them. Optimized: campaigns whose budget strategy is Optimized share what is left of the account budget after the fixed-budget campaigns' daily budgets are reserved, re-split every few minutes toward the ones earning the most tap-throughs per unit of spend. The account budget stays a hard cap on every campaign, fixed or optimized. It needs at least two Optimized campaigns; below that it does nothing.": "手動：各キャンペーンが自分の日予算を持ち、アカウント予算は全キャンペーンの上限として働きます。最適化：固定予算のキャンペーンの日予算を差し引いた残りのアカウント予算を、予算戦略が「最適化」のキャンペーン間で、支出あたりのタップスルーが多いものへ数分ごとに再配分します。アカウント予算は固定・最適化を問わず全キャンペーンの上限のままです。「最適化」のキャンペーンが2件以上必要で、それ未満では何もしません。",
 	"Optimized budget mode": "最適化予算モード",
 	"The account budget is re-split across campaigns whose budget strategy is Optimized.": "予算戦略が「最適化」のキャンペーン間でアカウント予算を再配分しています。",
 	"Budget strategy":      "予算戦略",

--- a/platform/templates/advertiser/account.html
+++ b/platform/templates/advertiser/account.html
@@ -104,6 +104,6 @@
     </button>
   </form>
   <p class="text-xs text-gray-400 mt-3">{{t "Changes apply immediately. Today's spend is not reset."}}</p>
-  <p class="text-xs text-gray-400 mt-1">{{t "Manual: every campaign keeps its own daily budget and the account budget is a hard cap. Optimized: the account budget is re-split every few minutes across the campaigns whose budget strategy is Optimized, toward the ones earning the most tap-throughs per unit of spend. It needs at least two such campaigns; below that it does nothing."}}</p>
+  <p class="text-xs text-gray-400 mt-1">{{t "Manual: every campaign keeps its own daily budget and the account budget is a hard cap on all of them. Optimized: campaigns whose budget strategy is Optimized share what is left of the account budget after the fixed-budget campaigns' daily budgets are reserved, re-split every few minutes toward the ones earning the most tap-throughs per unit of spend. The account budget stays a hard cap on every campaign, fixed or optimized. It needs at least two Optimized campaigns; below that it does nothing."}}</p>
 </div>
 {{end}}


### PR DESCRIPTION
Closes #99. Found while setting up the first GKE test advertiser (#38): with a mix of `auto` and `fixed` campaigns under an Optimized account, the allocator was handed the **whole** account daily budget and never saw the fixed campaigns.

## What happened

`CboPlanner.plan` filtered to the auto campaigns and passed `accountDaily` straight through, so the allocator split the full account budget across the auto pool. Fixed siblings spent from the same account budget first-come-first-served (the account cap is checked before any campaign reserve). Nobody overspent, but whichever campaigns spent earliest won the money, the auto walls were then stopped by the account cap rather than by the split, and the allocator read those stops as `InsufficientBudget` → exhausted → held its walls. The mixed case is the whole reason the per-campaign opt-in exists ("protect this campaign"), and it did not behave.

## Change (planner-local)

`poolBudget = max(0, accountDaily − Σ dailyBudget of live fixed campaigns)`, used for the day-start split, newcomer priors and `allocate`. A fixed campaign keeps its money; the allocator pools the rest. When the fixed walls reach the account budget the plan pushes nothing with the note `fixed walls (…) reach the account budget (…); nothing to allocate`. Not-live fixed campaigns reserve nothing.

## Tests (`CboPlannerSpec`, new block)

- two auto campaigns on 50 + 50 beside a fixed 40, account 100 → walls after the plan sum to **60**; the same pool without the fixed sibling keeps **100**;
- a paused fixed campaign reserves nothing;
- fixed walls at the account budget → empty plan, note says so.

50/50 across the CBO suites. No allocator, wire-model or dashboard change; #98 (selector placement) is independent.

https://claude.ai/code/session_01VESW511vk3rJ5Zci7Egb7d
