### PR TITLE
feat(cbo): show the day's budget movement on the campaigns page

### DIFF
--- a/modules/api/src/main/scala/promovolve/api/ApiJsonFormats.scala
+++ b/modules/api/src/main/scala/promovolve/api/ApiJsonFormats.scala
@@ -14,7 +14,7 @@ trait ApiJsonFormats extends DefaultJsonProtocol {
   given RootJsonFormat[Advertiser] = jsonFormat5(Advertiser.apply)
   given RootJsonFormat[AdvertiserList] = jsonFormat2(AdvertiserList.apply)
   given RootJsonFormat[BudgetStatus] = jsonFormat4(BudgetStatus.apply)
-  given RootJsonFormat[AdvertiserDetail] = jsonFormat9(AdvertiserDetail.apply)
+  given RootJsonFormat[AdvertiserDetail] = jsonFormat10(AdvertiserDetail.apply)
   given RootJsonFormat[SetTimezoneRequest] = jsonFormat1(SetTimezoneRequest.apply)
 
   // Campaign

--- a/modules/api/src/main/scala/promovolve/api/ApiModels.scala
+++ b/modules/api/src/main/scala/promovolve/api/ApiModels.scala
@@ -59,7 +59,12 @@ object ApiModels {
       createdAt: String,
       updatedAt: String,
       // "manual" | "optimized" (Campaign Budget Optimization).
-      budgetMode: Option[String] = None
+      budgetMode: Option[String] = None,
+      // While optimized: each pooled campaign's daily budget as of the start
+      // of the budget day, keyed by campaign id (money string), so a client
+      // can show "started today at X, moved Y" against the current daily
+      // budget (#103). Absent under manual.
+      cboDayStart: Option[Map[String, String]] = None
   )
 
   // ----------------- Campaign -----------------

--- a/modules/api/src/main/scala/promovolve/api/EndpointRoutes.scala
+++ b/modules/api/src/main/scala/promovolve/api/EndpointRoutes.scala
@@ -1451,7 +1451,13 @@ class EndpointRoutes(
           ),
           createdAt = nowIso,
           updatedAt = nowIso,
-          budgetMode = Some(info.budgetMode)
+          budgetMode = Some(info.budgetMode),
+          cboDayStart =
+            if (info.budgetMode == CboBudgetMode.Optimized && info.cboDayStart.nonEmpty)
+              Some(info.cboDayStart.map { case (id, wall) =>
+                id.value -> formatMoney(BigDecimal(wall).setScale(4, BigDecimal.RoundingMode.HALF_UP))
+              })
+            else None
         )
       )).recover { case _: java.util.concurrent.TimeoutException =>
         Left(ErrorResponse("advertiser_not_found", s"Advertiser $advertiserId not found"))

--- a/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
@@ -354,7 +354,7 @@ object AdvertiserEntity {
     eph.lastSnapshots = Vector.empty
     eph.cappedLast = Set.empty
     eph.dayStartPending = rolled.budgetMode == CboBudgetMode.Optimized
-    rolled.withCboPriors(priors)
+    rolled.withCboPriors(priors).copy(cboDayStart = Map.empty)
   }
 
   /** (dayStart, dayLengthSeconds) of the current budget window. */
@@ -383,7 +383,7 @@ object AdvertiserEntity {
         Effect.none.thenReply(replyTo)(s => BudgetModeUpdated(s.advertiserId, s.budgetMode))
       else
         Effect
-          .persist(state.copy(budgetMode = mode))
+          .persist(state.copy(budgetMode = mode, cboDayStart = Map.empty))
           .thenRun { _ =>
             cboCtx.eph.reset()
             ctx.log.info("Budget mode for advertiser {}: '{}' -> '{}'", state.advertiserId.value, state.budgetMode,
@@ -467,8 +467,11 @@ object AdvertiserEntity {
         if (plan.pushes.isEmpty && plan.note.nonEmpty)
           ctx.log.debug("CBO advertiser {}: {}", state.advertiserId.value, plan.note)
 
-        if (plan.priors != state.priorsForCbo)
-          Effect.persist(state.withCboPriors(plan.priors)).thenRun(_ => pushBudgets())
+        val dayStartWalls = CboPlanner.dayStartWalls(state.cboDayStart, CboPlanner.eligible(snapshots), plan)
+        if (plan.priors != state.priorsForCbo || dayStartWalls != state.cboDayStart)
+          Effect
+            .persist(state.withCboPriors(plan.priors).copy(cboDayStart = dayStartWalls))
+            .thenRun(_ => pushBudgets())
         else {
           pushBudgets()
           Effect.none
@@ -878,7 +881,9 @@ object AdvertiserEntity {
       campaignIds: Set[CampaignId],
       siteDomainBlocklist: Set[String],
       timezone: String = "",
-      budgetMode: String = CboBudgetMode.Manual
+      budgetMode: String = CboBudgetMode.Manual,
+      /** Day-start walls of the pooled campaigns while optimized (#103); empty otherwise. */
+      cboDayStart: Map[CampaignId, Double] = Map.empty
   ) extends promovolve.CborSerializable
 
   /**
@@ -1186,7 +1191,12 @@ object AdvertiserEntity {
       budgetMode: String = CboBudgetMode.Manual,
       // Per-campaign Gamma priors on tap-throughs per unit of spend, rolled
       // at the day boundary. Default-empty is Jackson-safe.
-      cboPriors: Map[CampaignId, CboPrior] = Map.empty
+      cboPriors: Map[CampaignId, CboPrior] = Map.empty,
+      // Each pooled campaign's wall at the start of the budget day, so the
+      // dashboard can say "started today at X, moved Y" (#103). Cleared at
+      // the day roll and when the mode leaves optimized. Default-empty is
+      // Jackson-safe.
+      cboDayStart: Map[CampaignId, Double] = Map.empty
   ) extends CborSerializable {
     def addCampaign(campaignId: CampaignId): State =
       copy(campaignIds = campaignIds + campaignId)
@@ -1327,7 +1337,7 @@ object AdvertiserEntity {
       spendToday.value < dailyBudget.value
 
     def toInfo: AdvertiserInfo =
-      AdvertiserInfo(advertiserId, name, status, campaignIds, siteDomainBlocklist, timezone, budgetMode)
+      AdvertiserInfo(advertiserId, name, status, campaignIds, siteDomainBlocklist, timezone, budgetMode, cboDayStart)
 
     def priorsForCbo: Map[CampaignId, CboAllocator.GammaPrior] =
       cboPriors.map { case (id, p) => id -> CboAllocator.GammaPrior(p.alpha, p.beta) }

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
@@ -58,6 +58,26 @@ object CboPlanner {
   def material(current: Double, target: Double, params: Params): Boolean =
     math.abs(target - current) >= math.max(PushEpsilon, params.minPushFraction * current)
 
+  /**
+   * Each pooled campaign's wall as of the start of the budget day, for the
+   * dashboard's "started today at X, moved Y" line (#103). On the tick that
+   * applies the day-start split the record is rebuilt from that split (the
+   * pushed wall, or the current one where the push was not material);
+   * otherwise campaigns already recorded keep their entry and campaigns
+   * new to the pool today are recorded at the wall they hold BEFORE this
+   * tick's push. Campaigns that left the pool keep their entry until the
+   * day rolls.
+   */
+  def dayStartWalls(
+      existing: Map[CampaignId, Double],
+      pool: Vector[Snapshot],
+      plan: Plan
+  ): Map[CampaignId, Double] = {
+    val pushed = plan.pushes.map(p => p.campaignId -> p.newDailyBudget).toMap
+    if (plan.dayStartApplied) pool.map(s => s.campaignId -> pushed.getOrElse(s.campaignId, s.dailyBudget)).toMap
+    else existing ++ pool.filterNot(s => existing.contains(s.campaignId)).map(s => s.campaignId -> s.dailyBudget)
+  }
+
   /** Minimum tap-throughs yesterday for the observed rate to seed the prior on its own. */
   val SeedMinCtas: Int = 5
 

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
@@ -152,6 +152,27 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
     }
   }
 
+  "CboPlanner.dayStartWalls (#103)" should {
+    val pool = Vector(snap(ca, 60, 0, 0), snap(cb, 40, 0, 0))
+    def planWith(pushes: Vector[Push], dayStart: Boolean): Plan =
+      Plan(pushes, Map.empty, dayStartApplied = dayStart, note = "")
+
+    "rebuild the record from the day-start split, pushed or held" in {
+      val p = planWith(Vector(Push(ca, 55.0, -5.0, 1.0, 1.0)), dayStart = true)
+      dayStartWalls(Map(ca -> 99.0, cc -> 1.0), pool, p) shouldBe Map(ca -> 55.0, cb -> 40.0)
+    }
+
+    "record a campaign new to the pool at the wall it holds before this tick's push" in {
+      val p = planWith(Vector(Push(cb, 30.0, -10.0, 1.0, 1.0)), dayStart = false)
+      dayStartWalls(Map(ca -> 50.0), pool, p) shouldBe Map(ca -> 50.0, cb -> 40.0)
+    }
+
+    "keep entries for campaigns that left the pool until the day rolls" in {
+      dayStartWalls(Map(ca -> 50.0, cc -> 20.0), pool, planWith(Vector.empty, dayStart = false)) shouldBe
+      Map(ca -> 50.0, cc -> 20.0, cb -> 40.0)
+    }
+  }
+
   "CboPlanner.material" should {
     "ignore moves under 1% of the wall and keep the absolute epsilon for tiny walls (#85)" in {
       material(10.0, 10.05, Params()) shouldBe false

--- a/platform/internal/handler/cbo_render_test.go
+++ b/platform/internal/handler/cbo_render_test.go
@@ -10,6 +10,7 @@ package handler
 
 import (
 	"bytes"
+	"math"
 	"strings"
 	"testing"
 
@@ -24,10 +25,13 @@ func TestCboTemplatesRender(t *testing.T) {
 	adv := &model.User{Email: "adv@test", Role: model.RoleAdvertiser}
 	nav := &listNav{Page: 1, TotalPages: 1, Total: 2, From: 1, To: 2}
 	rows := []campaignData{
-		{ID: "camp-a", Name: "A", Status: "active", DailyBudget: "70.00", MaxCPM: "5.00"},
-		{ID: "camp-b", Name: "B", Status: "active", DailyBudget: "30.00", MaxCPM: "5.00"},
+		{ID: "camp-a", Name: "A", Status: "active", DailyBudget: "70.00", MaxCPM: "5.00",
+			DayStartBudget: "50.00", BudgetMoved: "+20.00", BudgetMovedUp: true},
+		{ID: "camp-b", Name: "B", Status: "active", DailyBudget: "30.00", MaxCPM: "5.00",
+			DayStartBudget: "50.00", BudgetMoved: "-20.00"},
 	}
-	optimized := &advertiserBudget{DailyBudget: "100.00", Remaining: "60.00", SpendToday: "40.00", BudgetMode: "optimized"}
+	optimized := &advertiserBudget{DailyBudget: "100.00", Remaining: "60.00", SpendToday: "40.00", BudgetMode: "optimized",
+		MovedToday: "20.00"}
 	manual := &advertiserBudget{DailyBudget: "100.00", Remaining: "60.00", SpendToday: "40.00", BudgetMode: "manual"}
 
 	render := func(lang, name string, data pageData) string {
@@ -62,10 +66,28 @@ func TestCboTemplatesRender(t *testing.T) {
 		if !strings.Contains(html, i18n.T(lang, "Optimized budget mode")) {
 			t.Errorf("%s: account-budget line does not show the optimized mode", lang)
 		}
+		// The day's movement (#103): one line per pooled campaign, the net on the account line.
+		if n := strings.Count(html, "data-budget-moved"); n != 2 {
+			t.Errorf("%s: expected a budget-moved line on both campaigns, got %d", lang, n)
+		}
+		// html/template escapes "+" as &#43;.
+		if !strings.Contains(html, ">&#43;20.00</span>") || !strings.Contains(html, ">-20.00</span>") {
+			t.Errorf("%s: signed moves are not rendered", lang)
+		}
+		if !strings.Contains(html, strings.Replace(i18n.T(lang, "moved %s between campaigns today"), "%s", "20.00", 1)) {
+			t.Errorf("%s: account line does not show the net move", lang)
+		}
 
-		// Manual account: budgets editable, no badges.
+		// Manual account: budgets editable, no badges, no movement line.
+		manualRows := []campaignData{
+			{ID: "camp-a", Name: "A", Status: "active", DailyBudget: "70.00", MaxCPM: "5.00"},
+			{ID: "camp-b", Name: "B", Status: "active", DailyBudget: "30.00", MaxCPM: "5.00"},
+		}
 		html = render(lang, "advertiser/campaigns.html",
-			pageData{Title: "Campaigns", Nav: "campaigns", User: adv, AdvBudget: manual, ListNav: nav, Campaigns: rows})
+			pageData{Title: "Campaigns", Nav: "campaigns", User: adv, AdvBudget: manual, ListNav: nav, Campaigns: manualRows})
+		if strings.Contains(html, "data-budget-moved") {
+			t.Errorf("%s: budget-moved line rendered under a manual account", lang)
+		}
 		for _, v := range []string{"70.00", "30.00"} {
 			if disabled(html, v) {
 				t.Errorf("%s: budget input %s is disabled under a manual account", lang, v)
@@ -88,5 +110,27 @@ func TestCboTemplatesRender(t *testing.T) {
 	html := render(i18n.LangEN, "advertiser/account.html", pageData{Title: "Account", Nav: "account", User: adv, BudgetUnset: true})
 	if !strings.Contains(html, `name="budgetMode" value="manual" checked`) {
 		t.Errorf("account page without a budget does not default to manual")
+	}
+}
+
+func TestBudgetMoved(t *testing.T) {
+	cases := []struct {
+		dayStart, daily     string
+		wantStart, wantMove string
+		wantUp              bool
+		wantAbs             float64
+	}{
+		{"", "12.40", "", "", false, 0},
+		{"10.00", "12.40", money("10.00"), "+" + money("2.4000"), true, 2.4},
+		{"10.00", "8.90", money("10.00"), "-" + money("1.1000"), false, 1.1},
+		{"10.00", "10.00", money("10.00"), "", false, 0},
+		{"x", "10.00", "", "", false, 0},
+	}
+	for _, c := range cases {
+		start, move, up, abs := budgetMoved(c.dayStart, c.daily)
+		if start != c.wantStart || move != c.wantMove || up != c.wantUp || math.Abs(abs-c.wantAbs) > 1e-9 {
+			t.Errorf("budgetMoved(%q, %q) = (%q, %q, %v, %v), want (%q, %q, %v, %v)",
+				c.dayStart, c.daily, start, move, up, abs, c.wantStart, c.wantMove, c.wantUp, c.wantAbs)
+		}
 	}
 }

--- a/platform/internal/handler/pages.go
+++ b/platform/internal/handler/pages.go
@@ -925,17 +925,22 @@ type campaignData struct {
 	AdProductCategory string
 	DailyBudget       string
 	MaxCPM            string
-	LandingURL        string
-	SpendToday        string
-	BudgetPct         float64
-	Impressions       int
-	Clicks            int
-	CTR               string
-	ECPM              string // effective CPM: spend / impressions * 1000
-	LifetimeSpend     string // projection totalSpend, base-currency formatted
-	BidsToday         int
-	WinRate           string // e.g. "45.2%"
-	WinRateClass      string // CSS class: text-red-600, text-amber-600, text-green-600
+	// While the account is optimized (#103): the wall this campaign started
+	// the day with, and the signed move since ("+2.40"); empty under manual.
+	DayStartBudget string
+	BudgetMoved    string
+	BudgetMovedUp  bool
+	LandingURL     string
+	SpendToday     string
+	BudgetPct      float64
+	Impressions    int
+	Clicks         int
+	CTR            string
+	ECPM           string // effective CPM: spend / impressions * 1000
+	LifetimeSpend  string // projection totalSpend, base-currency formatted
+	BidsToday      int
+	WinRate        string // e.g. "45.2%"
+	WinRateClass   string // CSS class: text-red-600, text-amber-600, text-green-600
 	// Opted in to bid on pages with no contextual match (filler
 	// auction). Drives the checkbox on campaigns.html.
 	BidOnUnmatchedContext bool
@@ -992,6 +997,33 @@ type campaignData struct {
 	EndAtPassed    bool
 }
 
+// budgetMoved renders a campaign's day-start wall and its move since, for
+// the campaigns page under an optimized account (#103). dayStart is the
+// money string from the core (empty when the campaign is not pooled or the
+// account is manual); daily is the current daily budget. Returns the
+// formatted day-start wall, the signed move ("+2.40" / "-1.10", empty when
+// unchanged), whether it went up, and the absolute move for the account
+// total.
+func budgetMoved(dayStart, daily string) (string, string, bool, float64) {
+	if dayStart == "" {
+		return "", "", false, 0
+	}
+	from, err1 := strconv.ParseFloat(dayStart, 64)
+	to, err2 := strconv.ParseFloat(daily, 64)
+	if err1 != nil || err2 != nil {
+		return "", "", false, 0
+	}
+	delta := to - from
+	if math.Abs(delta) < 0.00005 {
+		return money(dayStart), "", false, 0
+	}
+	sign := "+"
+	if delta < 0 {
+		sign = "-"
+	}
+	return money(dayStart), sign + money(strconv.FormatFloat(math.Abs(delta), 'f', 4, 64)), delta > 0, math.Abs(delta)
+}
+
 type advertiserBudget struct {
 	DailyBudget string
 	Remaining   string
@@ -999,6 +1031,10 @@ type advertiserBudget struct {
 	IsZero      bool
 	// "manual" | "optimized" (Campaign Budget Optimization).
 	BudgetMode string
+	// Net budget moved between campaigns today while optimized (#103): half
+	// the sum of absolute per-campaign moves, so one transfer reads once.
+	// Empty when nothing moved.
+	MovedToday string
 }
 
 type servedSite struct {
@@ -1025,7 +1061,8 @@ func (h *Handler) AdvertiserCampaigns(w http.ResponseWriter, r *http.Request) {
 			Remaining   string `json:"remaining"`
 			SpendToday  string `json:"spendToday"`
 		} `json:"budget"`
-		BudgetMode string `json:"budgetMode"`
+		BudgetMode  string            `json:"budgetMode"`
+		CboDayStart map[string]string `json:"cboDayStart"`
 	}
 	var servedSites []servedSite
 	servedBody, _ := h.coreGet("/v1/advertisers/me/served-sites?limit=50", claims)
@@ -1207,6 +1244,7 @@ func (h *Handler) AdvertiserCampaigns(w http.ResponseWriter, r *http.Request) {
 	// same boundary the budget day rolls on. Stored instants are
 	// unchanged; only their interpretation and display shift.
 	schedTz, schedLoc := h.accountTimeContext(r.Context(), claims.AdvertiserID)
+	movedTotal := 0.0
 	for _, c := range campResp.Data {
 		var startLocal, startDisplay string
 		var startFuture bool
@@ -1228,6 +1266,8 @@ func (h *Handler) AdvertiserCampaigns(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		freqN, freqWindow := freqCapFields(c.FrequencyCap)
+		dayStart, moved, movedUp, movedAbs := budgetMoved(advResp.CboDayStart[c.ID], c.Budget.Daily)
+		movedTotal += movedAbs
 		cd := campaignData{
 			ID:                      c.ID,
 			Name:                    c.Name,
@@ -1235,6 +1275,9 @@ func (h *Handler) AdvertiserCampaigns(w http.ResponseWriter, r *http.Request) {
 			AdProductCategory:       c.AdProductCategory,
 			DailyBudget:             money(c.Budget.Daily),
 			MaxCPM:                  money(c.Bidding.MaxCPM),
+			DayStartBudget:          dayStart,
+			BudgetMoved:             moved,
+			BudgetMovedUp:           movedUp,
 			LandingURL:              c.LandingURL,
 			BidOnUnmatchedContext:   c.BidOnUnmatchedContext,
 			Untargeted:              c.Untargeted,
@@ -1328,6 +1371,9 @@ func (h *Handler) AdvertiserCampaigns(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		campaigns = append(campaigns, cd)
+	}
+	if advBudget != nil && movedTotal > 0 {
+		advBudget.MovedToday = money(strconv.FormatFloat(movedTotal/2, 'f', 4, 64))
 	}
 
 	var avgCTR, avgWinRate string

--- a/platform/internal/i18n/ja.go
+++ b/platform/internal/i18n/ja.go
@@ -491,6 +491,8 @@ var ja = map[string]string{
 	"Optimized budget mode": "最適化予算モード",
 	"The account budget is re-split across all live campaigns.": "アカウント予算は稼働中の全キャンペーン間で再配分されます。",
 	"Managed by the account allocator while the account budget mode is Optimized. Switch the account to Manual to set it by hand.": "アカウントの予算モードが「最適化」の間はアカウントの配分器が管理します。手動で設定するにはアカウントを「手動」に切り替えてください。",
+	"started today at %s":                   "本日の開始時点は %s",
+	"moved %s between campaigns today":        "本日はキャンペーン間で %s を移動",
 	"Daily budget is set by the account allocator (Campaign Budget Optimization).": "日予算はアカウントの配分器（キャンペーン予算最適化）が設定しています。",
 	"Changes apply immediately. Today's spend is not reset.": "変更はすぐに適用されます。本日の消化額はリセットされません。",
 

--- a/platform/templates/advertiser/campaigns.html
+++ b/platform/templates/advertiser/campaigns.html
@@ -19,7 +19,7 @@
 <!-- Budget info line -->
 {{if .AdvBudget}}
 <div class="flex items-center justify-between mb-6 text-sm text-gray-500">
-  <span>{{t "Account budget: %s/day (%s remaining, %s spent today)" (money .AdvBudget.DailyBudget) (money .AdvBudget.Remaining) (money .AdvBudget.SpendToday)}}{{if eq .AdvBudget.BudgetMode "optimized"}} &middot; <span class="badge badge-info" title="{{t "The account budget is re-split across all live campaigns."}}">{{t "Optimized budget mode"}}</span>{{end}}</span>
+  <span>{{t "Account budget: %s/day (%s remaining, %s spent today)" (money .AdvBudget.DailyBudget) (money .AdvBudget.Remaining) (money .AdvBudget.SpendToday)}}{{if eq .AdvBudget.BudgetMode "optimized"}} &middot; <span class="badge badge-info" title="{{t "The account budget is re-split across all live campaigns."}}">{{t "Optimized budget mode"}}</span>{{if .AdvBudget.MovedToday}} &middot; {{t "moved %s between campaigns today" .AdvBudget.MovedToday}}{{end}}{{end}}</span>
   <a href="/advertiser/account" class="text-brand hover:underline">{{t "Edit"}}</a>
 </div>
 {{end}}
@@ -369,6 +369,9 @@
           <span>{{money .SpendToday}}</span>
           <span>{{money .DailyBudget}}</span>
         </div>
+        {{if .DayStartBudget}}
+        <p class="text-xs text-gray-400 mb-1 text-right" data-budget-moved>{{t "started today at %s" .DayStartBudget}}{{if .BudgetMoved}} &middot; <span class="{{if .BudgetMovedUp}}text-green-600{{else}}text-red-600{{end}}">{{.BudgetMoved}}</span>{{end}}</p>
+        {{end}}
         <div class="h-1.5 bg-gray-200 rounded-full">
           <div class="h-full rounded-full {{if gt .BudgetPct 90.0}}bg-red-500{{else if gt .BudgetPct 70.0}}bg-amber-500{{else}}bg-green-500{{end}}"
                style="width:{{if .BudgetPct}}{{.BudgetPct}}{{else}}0{{end}}%;"></div>


### PR DESCRIPTION
Closes #103. Under an Optimized account the dashboard showed the *state* of CBO but not the *motion* — a campaign's daily budget is the allocator's wall and changes through the day, with nothing recording what it started at. This makes the account-level model (#98) self-explanatory: one switch on the account page, and the campaigns page tells you what it did today.

## What the advertiser sees

- Under each campaign's budget bar, while the account is Optimized: **`started today at 10.00 · +2.40`** (green up, red down; the delta is omitted when unchanged).
- On the account-budget line: **`moved 3.10 between campaigns today`** — half the sum of absolute moves, so one transfer reads once.
- Nothing under Manual.

## Core

- `AdvertiserEntity.State.cboDayStart: Map[CampaignId, Double]` (Jackson-safe default). Rebuilt on the tick that applies the day-start split — the pushed wall, or the current one where the push was not material; a campaign new to the pool today is recorded at the wall it holds *before* its first push. Cleared at the day roll and when the mode leaves Optimized. Persisted with the priors (same event).
- The bookkeeping is the pure `CboPlanner.dayStartWalls`, unit-tested (rebuild on day start, newcomer recorded pre-push, departed campaigns kept until the roll).
- `AdvertiserInfo.cboDayStart` carries it out of the entity.

## API

`AdvertiserDetail.cboDayStart: Option[Map[String, String]]` (money strings by campaign id), present only while Optimized. `jsonFormat10`. No new endpoint — the dashboard already reads `/v1/advertisers/me` for the account line.

## Dashboard

`budgetMoved(dayStart, daily)` computes the formatted start, signed move, direction and absolute move; the campaigns handler joins `cboDayStart` onto the rows by campaign id and sums the account total. Template + `ja` catalog (two new printf strings). `cbo_render_test.go`: both lines render under Optimized with the right signs (`html/template` escapes `+` as `&#43;`), nothing renders under Manual; `TestBudgetMoved` covers the arithmetic and bad input.

## Not in scope

A per-tick timeline or yesterday's split — reporting, belongs with the campaign daily-stats cuts.

https://claude.ai/code/session_01VESW511vk3rJ5Zci7Egb7d
