### PR TITLE
fix(cbo): day-start split weighted by evidence toward the typed anchor

### DIFF
--- a/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/AdvertiserEntity.scala
@@ -383,7 +383,7 @@ object AdvertiserEntity {
         Effect.none.thenReply(replyTo)(s => BudgetModeUpdated(s.advertiserId, s.budgetMode))
       else
         Effect
-          .persist(state.copy(budgetMode = mode, cboDayStart = Map.empty))
+          .persist(state.copy(budgetMode = mode, cboDayStart = Map.empty, cboAnchor = Map.empty))
           .thenRun { _ =>
             cboCtx.eph.reset()
             ctx.log.info("Budget mode for advertiser {}: '{}' -> '{}'", state.advertiserId.value, state.budgetMode,
@@ -427,6 +427,10 @@ object AdvertiserEntity {
             s.exhausted
           )
         }
+        // Anchor: a campaign's wall the first time the optimizer sees it,
+        // before any push — the value the advertiser typed (#106).
+        val anchor = state.cboAnchor ++
+          snapshots.filterNot(s => state.cboAnchor.contains(s.campaignId)).map(s => s.campaignId -> s.dailyBudget)
         val plan = CboPlanner.plan(
           snapshots,
           state.priorsForCbo,
@@ -438,7 +442,8 @@ object AdvertiserEntity {
           rng = eph.rng,
           tick = eph.tick,
           lastPushTick = eph.lastPushTick,
-          cappedLast = eph.cappedLast
+          cappedLast = eph.cappedLast,
+          anchor = anchor
         )
         eph.lastSpent = snapshots.map(s => s.campaignId -> s.spent).toMap
         eph.lastSnapshots = snapshots
@@ -468,9 +473,9 @@ object AdvertiserEntity {
           ctx.log.debug("CBO advertiser {}: {}", state.advertiserId.value, plan.note)
 
         val dayStartWalls = CboPlanner.dayStartWalls(state.cboDayStart, CboPlanner.eligible(snapshots), plan)
-        if (plan.priors != state.priorsForCbo || dayStartWalls != state.cboDayStart)
+        if (plan.priors != state.priorsForCbo || dayStartWalls != state.cboDayStart || anchor != state.cboAnchor)
           Effect
-            .persist(state.withCboPriors(plan.priors).copy(cboDayStart = dayStartWalls))
+            .persist(state.withCboPriors(plan.priors).copy(cboDayStart = dayStartWalls, cboAnchor = anchor))
             .thenRun(_ => pushBudgets())
         else {
           pushBudgets()
@@ -1196,7 +1201,12 @@ object AdvertiserEntity {
       // dashboard can say "started today at X, moved Y" (#103). Cleared at
       // the day roll and when the mode leaves optimized. Default-empty is
       // Jackson-safe.
-      cboDayStart: Map[CampaignId, Double] = Map.empty
+      cboDayStart: Map[CampaignId, Double] = Map.empty,
+      // The daily budgets the advertiser typed, recorded at first sight of
+      // each campaign while optimized (the input is disabled under optimized,
+      // so this is always the last typed value): the day-start anchor (#106).
+      // Cleared when the mode changes. Default-empty is Jackson-safe.
+      cboAnchor: Map[CampaignId, Double] = Map.empty
   ) extends CborSerializable {
     def addCampaign(campaignId: CampaignId): State =
       copy(campaignIds = campaignIds + campaignId)

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboAllocator.scala
@@ -167,9 +167,7 @@ object CboAllocator {
        */
       minDrawShape: Double = 2048.0,
       /** Posterior decay applied at day roll: `alpha <- factor * (alpha + ctas)`. 0.5 = two-day half-life. */
-      dayRollDecay: Double = 0.5,
-      /** Day-start split = blend * yesterday's final split + (1 - blend) * equal split. */
-      dayStartBlend: Double = 0.20
+      dayRollDecay: Double = 0.5
   ) {
     require(explorationFloor >= 0 && explorationFloor <= 1, "explorationFloor in [0,1]")
     require(maxMovePerTick > 0 && maxMovePerTick < 1, "maxMovePerTick in (0,1)")
@@ -181,7 +179,6 @@ object CboAllocator {
     require(minPushFraction >= 0 && minPushFraction < 1, "minPushFraction in [0,1)")
     require(shrinkageCtas >= 0, "shrinkageCtas >= 0")
     require(dayRollDecay > 0 && dayRollDecay <= 1, "dayRollDecay in (0,1]")
-    require(dayStartBlend >= 0 && dayStartBlend <= 1, "dayStartBlend in [0,1]")
   }
 
   /** One live `strategy = auto` campaign as the allocator sees it this tick. */
@@ -548,25 +545,46 @@ object CboAllocator {
   }
 
   /**
-   * Day-start forward split: yesterday's final split blended with equal
-   * split, scaled to `accountDaily`. Campaigns absent from `yesterdayFinal`
-   * (new today) count as 0 on the yesterday side and 1/N on the equal side.
+   * Day-start split (#106). Each campaign's share of the account budget is
+   * yesterday's final share weighted by the campaign's evidence weight `w`
+   * (see `shrinkageCtas`), plus the advertiser's anchor share weighted by
+   * `1 - w`; the shares are normalised and scaled to `accountDaily`. The
+   * anchor is the daily budgets the advertiser typed, as proportions: their
+   * stated intent, the prior when the optimizer knows nothing. So a cold
+   * pool starts at the typed walls, a well-evidenced pool starts where it
+   * ended, and a squeezed campaign that barely spent (little evidence)
+   * drifts back toward its anchor each morning — re-entry in proportion to
+   * ignorance. A fixed 20/80 blend toward an even split reset the
+   * advertiser's walls and the optimizer's learning every midnight.
+   *
+   * A campaign absent from `yesterdayFinal` (new today) takes its anchor
+   * share on the yesterday side; a campaign absent from `anchor` takes an
+   * equal share on the anchor side. Missing weights are 0.
    */
   def dayStartSplit[K](
       ids: Vector[K],
       yesterdayFinal: Map[K, Double],
-      accountDaily: Double,
-      params: Params = Params()
+      anchor: Map[K, Double],
+      weights: Map[K, Double],
+      accountDaily: Double
   ): Map[K, Double] = {
     val n = ids.size
     if (n == 0 || accountDaily <= 0) Map.empty
     else {
-      val ySum = ids.map(id => math.max(0.0, yesterdayFinal.getOrElse(id, 0.0))).sum
-      val blend = if (ySum > 0) params.dayStartBlend else 0.0
-      ids.map { id =>
-        val yShare = if (ySum > 0) math.max(0.0, yesterdayFinal.getOrElse(id, 0.0)) / ySum else 0.0
-        id -> accountDaily * (blend * yShare + (1.0 - blend) / n)
-      }.toMap
+      def positive(m: Map[K, Double], id: K): Option[Double] = m.get(id).filter(_ > 0.0)
+      val aSum = ids.flatMap(positive(anchor, _)).sum
+      val ySum = ids.flatMap(positive(yesterdayFinal, _)).sum
+      val aShare =
+        ids.map(id => id -> positive(anchor, id).filter(_ => aSum > 0).map(_ / aSum).getOrElse(1.0 / n)).toMap
+      val yShare =
+        ids.map(id =>
+          id -> positive(yesterdayFinal, id).filter(_ => ySum > 0).map(_ / ySum).getOrElse(aShare(id))).toMap
+      val raw = ids.map { id =>
+        val w = weights.getOrElse(id, 0.0).max(0.0).min(1.0)
+        id -> (w * yShare(id) + (1.0 - w) * aShare(id))
+      }
+      val total = raw.map(_._2).sum
+      raw.map { case (id, r) => id -> (if (total > 0) accountDaily * r / total else accountDaily / n) }.toMap
     }
   }
 }

--- a/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
+++ b/modules/core/src/main/scala/promovolve/advertiser/cbo/CboPlanner.scala
@@ -121,7 +121,7 @@ object CboPlanner {
    * Plan one tick.
    *
    * @param lastSpent       each campaign's spend as of the previous tick (for instantaneous pace)
-   * @param dayStartPending true on the first tick after a budget-day roll: push the 20/80 split
+   * @param dayStartPending true on the first tick after a budget-day roll: push the evidence-weighted day-start split (#106)
    * @param tick            this tick's ordinal in the entity's incarnation
    * @param lastPushTick    the tick each campaign's wall was last pushed (for `wallSettled`)
    * @param cappedLast      campaigns capacity-capped on the previous tick (for `cappedLastTick`)
@@ -138,7 +138,9 @@ object CboPlanner {
       params: Params = Params(),
       tick: Long = 0L,
       lastPushTick: Map[CampaignId, Long] = Map.empty,
-      cappedLast: Set[CampaignId] = Set.empty
+      cappedLast: Set[CampaignId] = Set.empty,
+      /** The advertiser's typed daily budgets, the day-start anchor (#106); empty = equal shares. */
+      anchor: Map[CampaignId, Double] = Map.empty
   ): Plan = {
     val pool = eligible(snapshots)
     if (pool.size < MinCampaigns)
@@ -153,8 +155,16 @@ object CboPlanner {
 
       if (dayStartPending) {
         val ids = pool.map(_.campaignId)
+        // Trust yesterday's split per campaign exactly as much as the tick
+        // trusts the campaign's rate: the evidence weight of its day-roll
+        // posterior against the pool (#93, #106).
+        val poolRate = CboAllocator.poolRateOf(ids.map(seeded))
+        val weights = ids.map { id =>
+          id -> CboAllocator.evidenceWeight(CboAllocator.evidenceOf(seeded(id), poolRate), params)
+        }.toMap
         val split =
-          CboAllocator.dayStartSplit(ids, pool.map(s => s.campaignId -> s.dailyBudget).toMap, accountDaily, params)
+          CboAllocator.dayStartSplit(ids, pool.map(s => s.campaignId -> s.dailyBudget).toMap, anchor, weights,
+            accountDaily)
         val pushes = pool.flatMap { s =>
           val target = s.spent + split.getOrElse(s.campaignId, 0.0)
           if (!material(s.dailyBudget, target, params)) None

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboAllocatorSpec.scala
@@ -590,24 +590,46 @@ class CboAllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckProperty
     }
   }
 
-  "dayStartSplit" should {
-    "blend yesterday's final split 20/80 with equal split and sum to the account budget" in {
-      val split = dayStartSplit(Vector("a", "b"), Map("a" -> 90.0, "b" -> 10.0), 100.0)
-      split("a") shouldBe (0.2 * 0.9 + 0.8 * 0.5) * 100 +- Eps
-      split("b") shouldBe (0.2 * 0.1 + 0.8 * 0.5) * 100 +- Eps
-      split.values.sum shouldBe 100.0 +- Eps
+  "dayStartSplit (#106)" should {
+    val ids = Vector("a", "b", "c")
+    val typed = Map("a" -> 1000.0, "b" -> 1000.0, "c" -> 1000.0)
+    val yesterday = Map("a" -> 1800.0, "b" -> 900.0, "c" -> 300.0)
+
+    "trust yesterday per campaign by its evidence weight and fall back to the typed anchor" in {
+      // The worked example of #106: A well-evidenced keeps most of its 1800,
+      // C squeezed and barely spent drifts back toward its typed 1000.
+      val split = dayStartSplit(ids, yesterday, typed, Map("a" -> 0.9, "b" -> 0.6, "c" -> 0.2), 3000.0)
+      split("a") shouldBe 1465.9 +- 0.1
+      split("b") shouldBe 801.1 +- 0.1
+      split("c") shouldBe 733.0 +- 0.1
+      split.values.sum shouldBe 3000.0 +- Eps
     }
 
-    "give a campaign new today its equal share of the 80%" in {
-      val split = dayStartSplit(Vector("a", "b", "c"), Map("a" -> 60.0, "b" -> 40.0), 90.0)
-      split("c") shouldBe 0.8 / 3 * 90 +- Eps
-      split.values.sum shouldBe 90.0 +- Eps
+    "give the anchor exactly at zero evidence and yesterday exactly at full evidence" in {
+      val cold = dayStartSplit(ids, yesterday, typed, Map.empty, 3000.0)
+      ids.foreach(id => cold(id) shouldBe typed(id) +- Eps)
+      val sure = dayStartSplit(ids, yesterday, typed, ids.map(_ -> 1.0).toMap, 3000.0)
+      ids.foreach(id => sure(id) shouldBe yesterday(id) +- Eps)
     }
 
-    "fall back to an equal split when there is no yesterday" in {
-      val split = dayStartSplit(Vector("a", "b"), Map.empty[String, Double], 50.0)
-      split("a") shouldBe 25.0 +- Eps
-      split("b") shouldBe 25.0 +- Eps
+    "give a campaign new today its anchor share, and one without an anchor an equal share" in {
+      // c is new today (no yesterday): it enters at its anchor share of the
+      // pot (a third) on the yesterday side too, and the normalisation then
+      // spreads the dilution over everyone — a and b keep their 2:1.
+      val newToday = dayStartSplit(ids, yesterday - "c", typed, ids.map(_ -> 1.0).toMap, 3000.0)
+      newToday("c") shouldBe 750.0 +- Eps
+      newToday("a") shouldBe 1500.0 +- Eps
+      newToday("b") shouldBe 750.0 +- Eps
+      newToday.values.sum shouldBe 3000.0 +- Eps
+      // No anchor anywhere and no evidence: an even split.
+      val even = dayStartSplit(Vector("a", "b"), Map.empty[String, Double], Map.empty[String, Double], Map.empty, 50.0)
+      even("a") shouldBe 25.0 +- Eps
+      even("b") shouldBe 25.0 +- Eps
+    }
+
+    "scale to the account budget whatever yesterday and the anchor summed to" in {
+      val split = dayStartSplit(ids, yesterday, Map("a" -> 5.0, "b" -> 3.0, "c" -> 2.0), Map("a" -> 0.5), 900.0)
+      split.values.sum shouldBe 900.0 +- Eps
     }
   }
 }

--- a/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
+++ b/modules/core/src/test/scala/promovolve/advertiser/cbo/CboPlannerSpec.scala
@@ -34,8 +34,10 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
       elapsed: Double = 0.5,
       lastSpent: Map[CampaignId, Double] = Map.empty,
       dayStartPending: Boolean = false,
-      seed: Long = 1L
-  ): Plan = plan(snaps, priors, accountDaily, elapsed, 1.0 / 96, lastSpent, dayStartPending, new Random(seed))
+      seed: Long = 1L,
+      anchor: Map[CampaignId, Double] = Map.empty
+  ): Plan =
+    plan(snaps, priors, accountDaily, elapsed, 1.0 / 96, lastSpent, dayStartPending, new Random(seed), anchor = anchor)
 
   "CboPlanner.eligible" should {
     "keep every live campaign regardless of its strategy field (#98)" in {
@@ -105,13 +107,21 @@ class CboPlannerSpec extends AnyWordSpec with Matchers {
       p.pushes.foreach(push => math.abs(push.newDailyBudget - 50.0) should be < 2.0)
     }
 
-    "apply the 20/80 day-start split once when pending and report it" in {
-      // Yesterday's final walls 90/10; today spent 0. Blend: 0.2*share + 0.8*equal.
-      val p = run(Vector(snap(ca, 90, 0, 0), snap(cb, 10, 0, 0)), dayStartPending = true)
-      p.dayStartApplied shouldBe true
-      p.note shouldBe "day-start split"
-      p.pushes.find(_.campaignId == ca).get.newDailyBudget shouldBe (0.2 * 0.9 + 0.8 * 0.5) * 100 +- Eps
-      p.pushes.find(_.campaignId == cb).get.newDailyBudget shouldBe (0.2 * 0.1 + 0.8 * 0.5) * 100 +- Eps
+    "apply the evidence-weighted day-start split once when pending and report it (#106)" in {
+      // Yesterday's final walls 90/10, typed anchor 50/50, today spent 0.
+      val snaps = Vector(snap(ca, 90, 0, 0), snap(cb, 10, 0, 0))
+      val anchor = Map(ca -> 50.0, cb -> 50.0)
+      // Cold priors: little evidence, so the split sits near the anchor.
+      val cold = run(snaps, dayStartPending = true, anchor = anchor)
+      cold.dayStartApplied shouldBe true
+      cold.note shouldBe "day-start split"
+      val aCold = cold.pushes.find(_.campaignId == ca).get.newDailyBudget
+      aCold should (be > 50.0 and be < 65.0)
+      cold.pushes.map(_.newDailyBudget).sum shouldBe 100.0 +- Eps
+      // Strong priors (30 tap-throughs each, decayed): the split keeps most of yesterday.
+      val sure = run(snaps, priors = Map(ca -> GammaPrior(30, 10), cb -> GammaPrior(30, 10)),
+        dayStartPending = true, anchor = anchor)
+      sure.pushes.find(_.campaignId == ca).get.newDailyBudget should be > 80.0
     }
 
     "feed last tick's spend into the allocator as tickSpend (a just-raised campaign is not capped back)" in {


### PR DESCRIPTION
Closes #106. The midnight budget reset now trusts yesterday's split exactly as much as the optimizer trusts its evidence, and falls back to the advertiser's typed budgets — not an even split — for what it doesn't trust.

## What changed for the advertiser

- **First midnight after enabling Optimized**: the walls you typed stand almost untouched (the optimizer has no evidence yet). On `advertiser@advertiser.com` the old rule cut the biggest campaign 3,738 → 1,748 and the best performer −223 at 00:09 JST; under this rule both keep their walls.
- **Later mornings**: campaigns with a track record keep what they earned; a campaign that was squeezed and barely spent drifts back toward its typed budget for another look. Nobody snaps to even.
- The #103 line on the campaigns page ("started today at X") now shows a number that means something.

## The rule

```
start_i ∝ w_i × yesterdayShare_i + (1 − w_i) × anchorShare_i     (normalised, × accountDaily)
```

`w_i = n / (n + shrinkageCtas)` is the evidence weight of the campaign's day-roll posterior against the pool — the same `evidenceOf` / `evidenceWeight` / `poolRateOf` the tick uses (#93). `n` counts tap-throughs seen (decayed lifetime) or expected at the pool rate over spend seen, whichever is larger, so spend without tap-throughs is evidence of a low rate, not ignorance. The anchor is `State.cboAnchor`: each campaign's wall at first sight while Optimized (the budget input is disabled under Optimized, so it is always the last typed value), cleared on a mode change.

Worked example (in the spec): account 3,000, typed 1,000 × 3, yesterday 1,800 / 900 / 300, `w` 0.9 / 0.6 / 0.2 → **1,466 / 801 / 733**.

## Code

- `CboAllocator.dayStartSplit(ids, yesterdayFinal, anchor, weights, accountDaily)`; `Params.dayStartBlend` removed. Absent from yesterday → anchor share; absent from anchor → equal share; missing weight → 0.
- `CboPlanner.plan(..., anchor)` derives the weights from the seeded priors on the `dayStartPending` tick.
- `AdvertiserEntity`: `cboAnchor` persisted with the priors and the day-start walls; recorded before any push.

## Tests

`CboAllocatorSpec.dayStartSplit (#106)`: the worked example; zero evidence → anchor exactly, full evidence → yesterday exactly; a campaign new today takes its anchor share, no anchor → even; the sum is always the account budget. `CboPlannerSpec`: cold priors put the split near the anchor, strong priors keep most of yesterday. Symmetric and threefold-gap simulated days unchanged.

## Gate after deploy

`scripts/cbo-gate.sh --seeds 4 scarce symmetric` on the DD cluster pointed at the deployed digest (images are built from main), before Optimized is enabled on any account beyond the test advertiser. Pass = symmetric day-3 drift ≤ 0.15 in every valid seed, scarce wall direction correct. The risk this checks: a lucky day-1 split rests on few tap-throughs, so its `w` is low and most of it is returned to the anchor — but that is the claim, and the gate is where it is tested.

https://claude.ai/code/session_01VESW511vk3rJ5Zci7Egb7d
