### PR TITLE
chore(deps): Limit routine Dependabot updates to minor and patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 
 # Keep Dependabot's default `dependencies` label.
+# Use allow.update-types so major security fixes are not excluded by an ignore rule.
 updates:
   - package-ecosystem: "sbt"
     directory: "/"
@@ -11,6 +12,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
     # Slick modules share a release; unrelated dependencies need separate reviews.
@@ -37,6 +43,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -49,6 +60,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -61,6 +77,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -73,6 +94,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -87,6 +113,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -101,6 +132,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 
@@ -113,5 +149,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies


### PR DESCRIPTION
## Summary

Limit routine Dependabot updates to minor and patch releases across all eight configured ecosystems. Use `allow.update-types` so security updates can still require a major upgrade.

Preserve existing schedules, cooldowns, PR limits, directories, and Slick groups. Dependency updates continue to require manual review and merging.

## Validation

YAML parsing, validation of all eight allow rules, comparison of unchanged settings against the base, and diff checks passed. Independent adversarial review found no actionable issues.

GitHub documents that `allow.update-types` affects version updates only, not security updates. Actual PR generation, particularly classification of non-SemVer Docker tags, remains unverified until the configuration reaches main.

Related to #12.
