### PR TITLE
fix(dependabot): bypass semver filtering for composite sbt tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,9 @@ updates:
       default-days: 7
     open-pull-requests-limit: 1
     allow:
+      # Composite Java/sbt/Scala tags break Dependabot's SemVer allow filtering.
+      # Review all component versions manually, including major updates.
+      - dependency-name: "sbtscala/scala-sbt"
       - dependency-name: "*"
         update-types:
           - "version-update:semver-minor"


### PR DESCRIPTION
## Summary

https://github.com/promovolve/promovolve/actions/runs/34671076425/job/103492418798

Dependabot's Docker update job fails while applying minor/patch filtering to the composite `sbtscala/scala-sbt` tag, raising `Malformed version number string 9_1.12.11_3.8.3`.

Add a dependency-specific allow rule without SemVer filtering. This permits major updates for manual review of the Java, sbt, and Scala components while preserving filtering for other images, the seven-day cooldown, and the PR limit.

## Validation

- Reproduced the malformed-version exception locally with the current tag's suffix.
- Parsed the YAML and verified that the only configuration change is the dependency-specific exception.
- Verified that other Docker images retain minor/patch filtering; `git diff --check` passed.
- A hosted Dependabot rerun after this configuration reaches the default branch is still required to confirm recovery.
