### PR TITLE
fix(dependabot): skip unsupported composite sbt image tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,12 +118,16 @@ updates:
     open-pull-requests-limit: 1
     allow:
       # Composite Java/sbt/Scala tags break Dependabot's SemVer allow filtering.
-      # Review all component versions manually, including major updates.
+      # Keep this exception even while ignored: allow filtering runs before exclusion.
       - dependency-name: "sbtscala/scala-sbt"
       - dependency-name: "*"
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+    # Tag comparison also rejects the composite version; update this image manually
+    # until Dependabot supports it, then remove this temporary ignore rule.
+    ignore:
+      - dependency-name: "sbtscala/scala-sbt"
     labels:
       - dependencies
 


### PR DESCRIPTION
## Summary

The [Dependabot run after #126](https://github.com/promovolve/promovolve/actions/runs/34673581763/job/103499354399) passes allow filtering but still fails when comparing the composite `sbtscala/scala-sbt` tag: `Malformed version number string 9_1.12.11_3.8.3`.

Temporarily ignore routine updates for this image and maintain it manually until Dependabot supports the tag. Retain its untyped `allow` exception because SemVer allow filtering is evaluated before complete exclusion; removing it would restore the earlier parsing failure. Other update settings remain unchanged.

## Validation

- YAML parsing and `git diff --check` passed.
- Verified that the only semantic configuration change is the dependency-specific ignore rule.
- Checked the exclusion and allow-filtering order in Dependabot's upstream implementation.
- Recovery remains unverified until a hosted Dependabot run uses this configuration.
