### PR TITLE
fix(dependabot): avoid parsing unsupported sbt image tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,17 +117,29 @@ updates:
       default-days: 7
     open-pull-requests-limit: 1
     allow:
-      # Composite Java/sbt/Scala tags break Dependabot's SemVer allow filtering.
-      # Keep this exception even while ignored: allow filtering runs before exclusion.
-      - dependency-name: "sbtscala/scala-sbt"
-      - dependency-name: "*"
+      # Wildcard allow and explicit ignore rules both trigger parsing of unsupported
+      # sbtscala/scala-sbt composite tags. Maintain that image manually for now.
+      # Add new Dockerfile images here, using repository names without registry hosts.
+      - dependency-name: "eclipse-temurin"
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
-    # Tag comparison also rejects the composite version; update this image manually
-    # until Dependabot supports it, then remove this temporary ignore rule.
-    ignore:
-      - dependency-name: "sbtscala/scala-sbt"
+      - dependency-name: "playwright/java"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "golang"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "distroless/static-debian12"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     labels:
       - dependencies
 


### PR DESCRIPTION
## Summary

The [Dependabot run after #130](https://github.com/promovolve/promovolve/actions/runs/34674105626/job/103500736706) still fails because GitHub serializes the image ignore rule as `>= 0`, causing ignore evaluation to parse the unsupported composite `sbtscala/scala-sbt` tag.

Replace the Docker wildcard allow rule with explicit entries for the other five image repositories, and remove both sbt-specific allow and ignore rules. Preserve minor/patch filtering and maintain the sbt image manually. New Dockerfile images must be added to this list; Compose updates remain covered by their separate configuration.

## Validation

- YAML parsing, image coverage, and `git diff --check` passed.
- Confirmed that other ecosystem settings, schedule, cooldown, labels, and PR limit are unchanged.
- A limited harness using upstream Job methods rejected `sbtscala/scala-sbt` without invoking version parsing; other services were stubbed.
- Recovery remains unverified until a hosted Dependabot run uses this configuration.
